### PR TITLE
hot-fix: upgrade APG version to 8.2.1 in setting.gradle

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.2.1" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false


### PR DESCRIPTION
# Upgrade Android Gradle Plugin to 8.2.1 for Java 21 Compatibility  

## Summary  
This PR updates the **Android Gradle Plugin (AGP) from 8.1.0 to 8.2.1** in `settings.gradle` to resolve compatibility issues with **Java 21** when setting `SourceCompatibility`.  

## Reason for Change  
The project previously failed to build due to a known issue in AGP versions **less than 8.2.1** when using **Java 21**.  
The error message suggested upgrading AGP to **8.2.1 or later**. 