### PR TITLE
Close #321 use monochrome color for dark / light seed

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -114,50 +114,33 @@ class AppTheme extends StatelessWidget {
     required Widget Function(ColorScheme lightDynamic, ColorScheme darkDynamic) builder,
   }) {
     return DynamicColorBuilder(builder: (ColorScheme? lightDynamic, ColorScheme? darkDynamic) {
-      if (provider.theme.colorSeed == Colors.black || provider.theme.colorSeed == Colors.white) {
-        final darkScheme = ColorScheme.dark(
-          outline: Colors.white10,
-          outlineVariant: Colors.white24,
-          primary: Colors.white,
-          onPrimary: Colors.black,
-          secondary: Colors.white,
-          onSecondary: Colors.black,
-          error: Colors.red[200]!,
-          onError: Colors.white,
-          surface: Color.alphaBlend(
-            Colors.white.withValues(alpha: 0.05),
-            Colors.black,
-          ),
-          onSurface: Colors.white,
-          surfaceContainerHighest: Colors.white,
-          secondaryContainer: Color.alphaBlend(Colors.white.withValues(alpha: 0.14), Colors.black),
-          onSecondaryContainer: Colors.white,
+      if (provider.theme.colorSeed != null) {
+        bool monochrome = provider.theme.colorSeed == Colors.black || provider.theme.colorSeed == Colors.white;
+        final lightScheme = ColorScheme.fromSeed(
+          seedColor: provider.theme.colorSeed!,
+          brightness: Brightness.light,
+          dynamicSchemeVariant: monochrome ? DynamicSchemeVariant.monochrome : DynamicSchemeVariant.tonalSpot,
         );
-
-        final lightScheme = ColorScheme.light(
-          outline: Colors.black12,
-          outlineVariant: Colors.black26,
-          primary: Colors.black87,
-          onPrimary: Colors.white,
-          secondary: Colors.black,
-          onSecondary: Colors.white,
-          error: Colors.red[600]!,
-          onError: Colors.black,
-          surface: Colors.white,
-          onSurface: Colors.black,
-          surfaceContainerHighest: Colors.white,
-          secondaryContainer: Color.alphaBlend(Colors.white.withValues(alpha: 0.14), Colors.white),
-          onSecondaryContainer: Colors.black,
+        final darkScheme = ColorScheme.fromSeed(
+          seedColor: provider.theme.colorSeed!,
+          brightness: Brightness.dark,
+          dynamicSchemeVariant: monochrome ? DynamicSchemeVariant.monochrome : DynamicSchemeVariant.tonalSpot,
         );
-
-        return builder(lightScheme, darkScheme);
-      } else if (provider.theme.colorSeed != null) {
-        final lightScheme = ColorScheme.fromSeed(seedColor: provider.theme.colorSeed!, brightness: Brightness.light);
-        final darkScheme = ColorScheme.fromSeed(seedColor: provider.theme.colorSeed!, brightness: Brightness.dark);
         return builder(lightScheme, darkScheme);
       } else {
-        lightDynamic ??= ColorScheme.fromSeed(seedColor: kDefaultColorSeed, brightness: Brightness.light);
-        darkDynamic ??= ColorScheme.fromSeed(seedColor: kDefaultColorSeed, brightness: Brightness.dark);
+        bool monochrome = kDefaultColorSeed == Colors.black || kDefaultColorSeed == Colors.white;
+
+        lightDynamic ??= ColorScheme.fromSeed(
+          seedColor: kDefaultColorSeed,
+          brightness: Brightness.light,
+          dynamicSchemeVariant: monochrome ? DynamicSchemeVariant.monochrome : DynamicSchemeVariant.tonalSpot,
+        );
+
+        darkDynamic ??= ColorScheme.fromSeed(
+          seedColor: kDefaultColorSeed,
+          brightness: Brightness.dark,
+          dynamicSchemeVariant: monochrome ? DynamicSchemeVariant.monochrome : DynamicSchemeVariant.tonalSpot,
+        );
       }
 
       return builder(lightDynamic, darkDynamic);

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -7,7 +7,12 @@ import 'package:storypad/core/objects/device_info_object.dart';
 const String kAppName = String.fromEnvironment('APP_NAME');
 
 const Color kSplashColor = Colors.transparent;
-const Color kDefaultColorSeed = Colors.orange;
+
+Color get kDefaultColorSeed => Platform.isIOS ? kDefaultColorSeedIos : kDefaultColorSeedAndroid;
+
+const Color kDefaultColorSeedIos = Colors.black;
+const Color kDefaultColorSeedAndroid = Colors.orange;
+
 const String kDefaultFontFamily = 'Quicksand';
 const FontWeight kDefaultFontWeight = FontWeight.normal;
 


### PR DESCRIPTION
This also remove all custom configuration and let ColorScheme handle generating monochrome color instead.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/e9a3c6b2-0983-4a7a-87a2-a8efa6bba60d" />
