### PR TITLE
Close #343 add home navigations

### DIFF
--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -26,6 +26,7 @@ import 'package:storypad/widgets/sp_loop_animation_builder.dart' show SpLoopAnim
 import 'package:storypad/widgets/sp_measure_size.dart' show SpMeasureSize;
 import 'package:storypad/widgets/sp_tap_effect.dart' show SpTapEffect, SpTapEffectType;
 import 'package:storypad/widgets/story_list/sp_story_listener_builder.dart' show SpStoryListenerBuilder;
+import 'package:storypad/widgets/story_list/sp_story_tile.dart' show SpStoryTile;
 import 'package:storypad/widgets/story_list/sp_story_tile_list_item.dart' show SpStoryTileListItem;
 import 'package:storypad/widgets/story_list/sp_story_list_timeline_verticle_divider.dart'
     show SpSpStoryListTimelineVerticleDivider;
@@ -42,6 +43,7 @@ part 'local_widgets/home_app_bar_message.dart';
 part 'local_widgets/home_empty.dart';
 part 'local_widgets/app_update_floating_button.dart';
 part 'local_widgets/rounded_indicator.dart';
+part 'local_widgets/home_timeline_side_bar.dart';
 
 class HomeView extends StatelessWidget {
   const HomeView({

--- a/lib/views/home/local_widgets/home_scaffold.dart
+++ b/lib/views/home/local_widgets/home_scaffold.dart
@@ -47,6 +47,8 @@ class _HomeScaffold extends StatelessWidget {
                     ],
                   ),
                 ),
+                // TODO: add something to home side bar
+                // buildTimelineSideBar(context),
                 Positioned(
                   left: 0,
                   right: 0,
@@ -66,6 +68,39 @@ class _HomeScaffold extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+
+  Widget buildTimelineSideBar(BuildContext viewContext) {
+    return Positioned(
+      bottom: 0,
+      child: SpStoryListMultiEditWrapper.listen(
+        context: viewContext,
+        builder: (context, state) {
+          return Visibility(
+            visible: !state.editing,
+            child: Container(
+              padding: EdgeInsets.only(
+                left: AppTheme.getDirectionValue(viewContext, 0.0, MediaQuery.of(viewContext).padding.left + 14.0)!,
+                right: AppTheme.getDirectionValue(viewContext, MediaQuery.of(viewContext).padding.left + 14.0, 0.0)!,
+                bottom: MediaQuery.of(viewContext).padding.bottom + 24.0,
+              ),
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  end: Alignment.topCenter,
+                  begin: Alignment.bottomCenter,
+                  colors: [
+                    Theme.of(context).colorScheme.surface,
+                    Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
+                    Theme.of(context).colorScheme.surface.withValues(alpha: 0.0)
+                  ],
+                ),
+              ),
+              child: _HomeTimelineSideBar(),
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/views/home/local_widgets/home_timeline_side_bar.dart
+++ b/lib/views/home/local_widgets/home_timeline_side_bar.dart
@@ -1,0 +1,63 @@
+part of '../home_view.dart';
+
+class _HomeTimelineSideBar extends StatelessWidget {
+  const _HomeTimelineSideBar();
+
+  @override
+  Widget build(BuildContext context) {
+    final double iconSize = SpStoryTile.monogramSize + 4;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      spacing: 8.0,
+      children: [
+        Container(
+          width: iconSize,
+          height: iconSize,
+          decoration: BoxDecoration(
+            border: Border.all(color: Theme.of(context).dividerColor),
+            color: Theme.of(context).colorScheme.surface,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.calendar_today_outlined,
+            size: 24.0,
+          ),
+        ),
+        Container(
+          width: iconSize,
+          height: iconSize,
+          decoration: BoxDecoration(
+            border: Border.all(color: Theme.of(context).dividerColor),
+            color: Theme.of(context).colorScheme.surface,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.emoji_emotions_outlined,
+            size: 24.0,
+          ),
+        ),
+        Container(
+          width: iconSize,
+          height: iconSize,
+          decoration: BoxDecoration(
+            border: Border.all(color: Theme.of(context).dividerColor),
+            color: Theme.of(context).colorScheme.surface,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(Icons.search),
+        ),
+        Container(
+          width: iconSize,
+          height: iconSize,
+          decoration: BoxDecoration(
+            border: Border.all(color: Theme.of(context).dividerColor),
+            color: Theme.of(context).colorScheme.surface,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(Icons.home_outlined),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
We could not add an actual nav bar directly as we already have a tab bar on the top. It would make the app less minimal. Instead, we will have icons that go along with the timeline. This will open up more possibilities including calendars, statistics, music, and more.

![Image](https://github.com/user-attachments/assets/68c3da8e-3c2d-4f70-a3d6-de63c02bae9f)