### PR TITLE
Close #375 make home page easier to navigate

### DIFF
--- a/lib/views/home/local_widgets/home_flexible_space_bar.dart
+++ b/lib/views/home/local_widgets/home_flexible_space_bar.dart
@@ -91,11 +91,7 @@ class _HomeFlexibleSpaceBar extends StatelessWidget {
         margin: viewModel.scrollInfo.extraExpandedHeight > 0 ? const EdgeInsets.only(bottom: 8.0) : null,
         child: SpTapEffect(
           effects: const [SpTapEffectType.touchableOpacity],
-          onTap: () {
-            SpDiscoverSheet(
-              params: const DiscoverRoute(),
-            ).show(context: context);
-          },
+          onTap: () => viewModel.openEndDrawer(context),
           child: FittedBox(
             child: Text(
               viewModel.year.toString(),

--- a/lib/views/home/local_widgets/home_scaffold.dart
+++ b/lib/views/home/local_widgets/home_scaffold.dart
@@ -17,6 +17,10 @@ class _HomeScaffold extends StatelessWidget {
   final Widget floatingActionButton;
   final Widget bottomNavigationBar;
 
+  Color? getBackgroundColor(BuildContext context) {
+    return kIsCupertino && AppTheme.isDarkMode(context) && AppTheme.isMonochrome(context) ? Colors.black : null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -43,8 +47,7 @@ class _HomeScaffold extends StatelessWidget {
               ],
             ),
           ),
-          // TODO: add something to home side bar
-          // buildTimelineSideBar(context),
+          buildTimelineSideBar(context),
           Positioned(
             left: 0,
             right: 0,
@@ -64,25 +67,7 @@ class _HomeScaffold extends StatelessWidget {
         builder: (context, state) {
           return Visibility(
             visible: !state.editing,
-            child: Container(
-              padding: EdgeInsets.only(
-                left: AppTheme.getDirectionValue(viewContext, 0.0, MediaQuery.of(viewContext).padding.left + 14.0)!,
-                right: AppTheme.getDirectionValue(viewContext, MediaQuery.of(viewContext).padding.left + 14.0, 0.0)!,
-                bottom: MediaQuery.of(viewContext).padding.bottom + 24.0,
-              ),
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  end: Alignment.topCenter,
-                  begin: Alignment.bottomCenter,
-                  colors: [
-                    Theme.of(context).colorScheme.surface,
-                    Theme.of(context).colorScheme.surface.withValues(alpha: 0.9),
-                    Theme.of(context).colorScheme.surface.withValues(alpha: 0.0)
-                  ],
-                ),
-              ),
-              child: const _HomeTimelineSideBar(),
-            ),
+            child: const _HomeTimelineSideBar(),
           );
         },
       ),

--- a/lib/views/home/local_widgets/home_timeline_side_bar.dart
+++ b/lib/views/home/local_widgets/home_timeline_side_bar.dart
@@ -3,14 +3,73 @@ part of '../home_view.dart';
 class _HomeTimelineSideBar extends StatelessWidget {
   const _HomeTimelineSideBar();
 
+  static const double iconSize = SpStoryTile.monogramSize + 8;
+
   @override
   Widget build(BuildContext context) {
-    const double iconSize = SpStoryTile.monogramSize + 4;
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      spacing: 8.0,
-      children: [
-        Container(
+    Color backgroundColor = Theme.of(context).scaffoldBackgroundColor;
+    double baseHorizontalPadding = 6.0;
+
+    return Container(
+      padding: EdgeInsets.only(
+        left: AppTheme.getDirectionValue(context, 0.0, MediaQuery.of(context).padding.left + baseHorizontalPadding)!,
+        right: AppTheme.getDirectionValue(context, MediaQuery.of(context).padding.right + baseHorizontalPadding, 0.0)!,
+        top: MediaQuery.of(context).padding.bottom + 24.0,
+        bottom: MediaQuery.of(context).padding.bottom + 24.0,
+      ),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          end: Alignment.topCenter,
+          begin: Alignment.bottomCenter,
+          colors: [
+            backgroundColor.withValues(alpha: 0.0),
+            backgroundColor.withValues(alpha: 0.8),
+            backgroundColor,
+            backgroundColor.withValues(alpha: 0.8),
+            backgroundColor.withValues(alpha: 0.0)
+          ],
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        spacing: 0.0,
+        children: [
+          // buildButton(
+          //   context: context,
+          //   child: const Icon(SpIcons.addFeeling, size: 24.0),
+          //   onTap: () {},
+          // ),
+          // buildButton(
+          //   context: context,
+          //   child: const Icon(SpIcons.search, size: 24.0),
+          //   onTap: () {},
+          // ),
+          buildButton(
+            context: context,
+            child: const Icon(SpIcons.calendar, size: 24.0),
+            onTap: () {
+              SpDiscoverSheet(
+                params: const DiscoverRoute(),
+              ).show(context: context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildButton({
+    required BuildContext context,
+    required Widget child,
+    required void Function()? onTap,
+  }) {
+    return SpTapEffect(
+      scaleActive: 0.9,
+      effects: [SpTapEffectType.scaleDown],
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(6.0),
+        child: Container(
           width: iconSize,
           height: iconSize,
           decoration: BoxDecoration(
@@ -18,35 +77,9 @@ class _HomeTimelineSideBar extends StatelessWidget {
             color: Theme.of(context).colorScheme.surface,
             shape: BoxShape.circle,
           ),
-          child: const Icon(
-            SpIcons.calendar,
-            size: 24.0,
-          ),
+          child: child,
         ),
-        Container(
-          width: iconSize,
-          height: iconSize,
-          decoration: BoxDecoration(
-            border: Border.all(color: Theme.of(context).dividerColor),
-            color: Theme.of(context).colorScheme.surface,
-            shape: BoxShape.circle,
-          ),
-          child: const Icon(
-            SpIcons.addFeeling,
-            size: 24.0,
-          ),
-        ),
-        Container(
-          width: iconSize,
-          height: iconSize,
-          decoration: BoxDecoration(
-            border: Border.all(color: Theme.of(context).dividerColor),
-            color: Theme.of(context).colorScheme.surface,
-            shape: BoxShape.circle,
-          ),
-          child: const Icon(SpIcons.search),
-        ),
-      ],
+      ),
     );
   }
 }

--- a/lib/widgets/story_list/sp_story_tile.dart
+++ b/lib/widgets/story_list/sp_story_tile.dart
@@ -21,6 +21,7 @@ import 'package:storypad/widgets/sp_markdown_body.dart';
 import 'package:storypad/widgets/sp_pop_up_menu_button.dart';
 import 'package:storypad/widgets/sp_single_state_widget.dart';
 import 'package:storypad/widgets/sp_story_labels.dart';
+import 'package:storypad/widgets/sp_tap_effect.dart';
 import 'package:storypad/widgets/story_list/sp_story_list_multi_edit_wrapper.dart';
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:storypad/core/databases/models/story_preferences_db_model.dart';
@@ -150,9 +151,10 @@ class SpStoryTile extends StatelessWidget {
           onLongPress = () => openPopUpMenu.call();
         }
 
-        return InkWell(
+        return SpTapEffect(
+          effects: [SpTapEffectType.touchableOpacity],
           onTap: onTap,
-          onLongPress: onLongPress,
+          onLongPressed: onLongPress,
           child: Container(
             padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16),
             child: Stack(


### PR DESCRIPTION
## What changes?
1. Both button on app bar will be open end drawer only
2. There is extra new button below to open calendar UI

Which mean, top button -> end drawer, bottom buttons -> bottom sheet. This is experimental, and expected to be more explicit to user with less confusing.

<img src="https://github.com/user-attachments/assets/21f6ab96-038e-4f3a-8bfe-22cc858ffd74" width="400px" />