### PR TITLE
Compress backup file

### DIFF
--- a/lib/core/objects/backup_file_object.dart
+++ b/lib/core/objects/backup_file_object.dart
@@ -17,8 +17,10 @@ class BackupFileObject {
   BackupFileObject({
     required this.createdAt,
     required this.device,
-    this.version = '1',
+    this.version = '2',
   });
+
+  bool? get hasCompression => version == '2';
 
   // v1: Backup::v1::2022-06-14T17:44:47.097469::Pixel 5.json
   String get fileName {
@@ -32,11 +34,17 @@ class BackupFileObject {
   }
 
   String get fileNameWithExtention {
-    return "$fileName.json";
+    if (version == '1') {
+      return "$fileName.json";
+    } else {
+      return "$fileName.zip";
+    }
   }
 
   static BackupFileObject? fromFileName(String fileName) {
+    if (fileName.endsWith(".zip")) fileName = fileName.replaceAll(".zip", "");
     if (fileName.endsWith(".json")) fileName = fileName.replaceAll(".json", "");
+
     List<String> value = fileName.trim().split(splitBy);
 
     if (value.isNotEmpty) {
@@ -44,6 +52,7 @@ class BackupFileObject {
 
       switch (version) {
         case "1":
+        case "2":
           try {
             int millisecondsEpoch = int.parse(value[2]);
             DateTime createdAt = DateTime.fromMillisecondsSinceEpoch(millisecondsEpoch);

--- a/lib/core/objects/backup_object.dart
+++ b/lib/core/objects/backup_object.dart
@@ -6,6 +6,10 @@ class BackupObject {
   final BackupFileObject fileInfo;
   final int version;
 
+  int? originalFileSize;
+
+  // BackupObject version is different from BackupFileObject version.
+  // they serve different purpose.
   static const int currentVersion = 1;
 
   BackupObject({

--- a/lib/core/objects/cloud_file_object.dart
+++ b/lib/core/objects/cloud_file_object.dart
@@ -29,6 +29,8 @@ class CloudFileObject {
     );
   }
 
+  bool? get hasCompression => getFileInfo()?.hasCompression;
+
   // story2025-01-20 21:31:05.234761.zip
   BackupFileObject? getFileInfo() {
     if (fileName == null) return null;

--- a/lib/core/services/backup_sync_steps/backup_latest_checker_service.dart
+++ b/lib/core/services/backup_sync_steps/backup_latest_checker_service.dart
@@ -77,7 +77,9 @@ class BackupLatestCheckerService {
       );
     }
 
-    final fileContent = await client.getFileContent(lastestBackupFile);
+    final result = await client.getFileContent(lastestBackupFile);
+    final fileContent = result?.$1;
+
     if (fileContent == null) {
       controller.add(BackupSyncMessage(
         processing: false,

--- a/lib/core/services/backup_sync_steps/backup_uploader_service.dart
+++ b/lib/core/services/backup_sync_steps/backup_uploader_service.dart
@@ -10,6 +10,7 @@ import 'package:storypad/core/repositories/backup_repository.dart';
 import 'package:storypad/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart';
 import 'package:storypad/core/services/backup_sync_steps/backup_sync_message.dart';
 import 'package:storypad/core/services/google_drive_client.dart';
+import 'package:storypad/core/services/gzip_service.dart';
 import 'package:storypad/core/types/file_path_type.dart';
 
 class BackupUploaderResponse {
@@ -122,6 +123,11 @@ class BackupUploaderService {
     debugPrint('BackupFileConstructor#constructFile encodingJson');
     String encodedJson = jsonEncode(backup.toContents());
     debugPrint('BackupFileConstructor#constructFile encodedJson');
+
+    if (backup.fileInfo.hasCompression == true) {
+      final compressed = GzipService.compress(encodedJson);
+      return file.writeAsBytes(compressed);
+    }
 
     return file.writeAsString(encodedJson);
   }

--- a/lib/core/services/gzip_service.dart
+++ b/lib/core/services/gzip_service.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+
+class GzipService {
+  static List<int> compress(String originalData) {
+    List<int> original = utf8.encode(originalData);
+    List<int> compressed = gzip.encode(original);
+
+    debugPrint('🚀 Original ${original.length} bytes');
+    debugPrint('🚀 Compressed ${compressed.length} bytes');
+
+    return compressed;
+  }
+}

--- a/lib/views/backups/backups_view_model.dart
+++ b/lib/views/backups/backups_view_model.dart
@@ -89,12 +89,16 @@ class BackupsViewModel extends ChangeNotifier with DisposeAwareMixin {
         await MessengerService.of(context).showLoading(
           debugSource: '$runtimeType#openCloudFile',
           future: () async {
-            final fileContent =
-                await context.read<BackupProvider>().repository.googleDriveClient.getFileContent(cloudFile);
+            final result = await context.read<BackupProvider>().repository.googleDriveClient.getFileContent(cloudFile);
+
+            final fileContent = result?.$1;
 
             if (fileContent == null) return null;
             dynamic decodedContents = jsonDecode(fileContent);
+
             final backupContent = BackupObject.fromContents(decodedContents);
+            backupContent.originalFileSize = result?.$2;
+
             return backupContent;
           },
         );

--- a/lib/views/backups/show/show_backup_content.dart
+++ b/lib/views/backups/show/show_backup_content.dart
@@ -11,6 +11,12 @@ class _ShowBackupContent extends StatelessWidget {
   Widget build(BuildContext context) {
     String? backupAt = DateFormatHelper.yMEd_jmNullable(backup.fileInfo.createdAt, context.locale);
 
+    String? sizeInKB;
+
+    if (backup.originalFileSize != null) {
+      sizeInKB = "${(backup.originalFileSize! / 1024).toStringAsFixed(2)}kb";
+    }
+
     return Scaffold(
       appBar: AppBar(
         titleSpacing: 0.0,
@@ -19,7 +25,10 @@ class _ShowBackupContent extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    backup.fileInfo.device.model,
+                    [
+                      backup.fileInfo.device.model,
+                      sizeInKB,
+                    ].join(" - "),
                     style: TextTheme.of(context).titleSmall,
                   ),
                   Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.12.3+380
+version: 2.12.4+381
 publish_to: none
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
This is data for my diary about 400 entries.

- Original size: 767,794 bytes ÷ 1024 = 749.8 KB
- Compressed size: 114,856 bytes ÷ 1024 = 112.2 KB

![Screenshot 2025-06-10 at 3 08 42 in the morning](https://github.com/user-attachments/assets/26857c31-2eb8-48f3-b44d-e8add08e47f7)

Sync between devices will be significantly faster!