### PR TITLE
Close #419 show label for new button for screen reader

### DIFF
--- a/lib/views/home/local_widgets/home_floating_buttons.dart
+++ b/lib/views/home/local_widgets/home_floating_buttons.dart
@@ -50,12 +50,26 @@ class _HomeFloatingButtonsState extends State<_HomeFloatingButtons> with SingleT
   Widget build(BuildContext context) {
     return FadeTransition(
       opacity: Tween<double>(begin: 1, end: 0.0).animate(animation),
-      child: FloatingActionButton(
+      child: buildButton(context),
+    );
+  }
+
+  Widget buildButton(BuildContext context) {
+    if (MediaQuery.accessibleNavigationOf(context)) {
+      return FloatingActionButton.extended(
+        tooltip: tr("button.new_story"),
+        onPressed: FeatureFlags.template ? () => toggle(context) : () => widget.viewModel.goToNewPage(context),
+        label: Text(tr("button.new_story")),
+        icon: const Icon(SpIcons.newStory),
+        shape: const StadiumBorder(),
+      );
+    } else {
+      return FloatingActionButton(
         tooltip: tr("button.new_story"),
         onPressed: FeatureFlags.template ? () => toggle(context) : () => widget.viewModel.goToNewPage(context),
         child: const Icon(SpIcons.newStory),
-      ),
-    );
+      );
+    }
   }
 
   Widget buildExpandedScaffold(BuildContext context) {


### PR DESCRIPTION
Currently, show label in FAB when accessibleNavigationOf is true only. Some app always open / hide it on scroll. Let's keep it simple for now.

<img width="367" alt="image" src="https://github.com/user-attachments/assets/9cc03525-d55c-4f64-a19f-ee10efd44d05" />
