### PR TITLE
Backup to google drive with delete record

### DIFF
--- a/lib/core/databases/adapters/base_db_adapter.dart
+++ b/lib/core/databases/adapters/base_db_adapter.dart
@@ -50,6 +50,9 @@ abstract class BaseDbAdapter<T extends BaseDbModel> {
 
   bool hasDeleted(int id);
 
+  // id: deleted_at
+  Future<Map<String, int>> getDeletedRecords();
+
   T modelFromJson(Map<String, dynamic> json);
 
   Future<void> afterCommit([T? model]) async {

--- a/lib/core/databases/adapters/objectbox/assets_box.dart
+++ b/lib/core/databases/adapters/objectbox/assets_box.dart
@@ -35,6 +35,16 @@ class AssetsBox extends BaseBox<AssetObjectBox, AssetDbModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<AssetObjectBox> conditions = AssetObjectBox_.permanentlyDeletedAt.notNull();
+    List<AssetObjectBox> result =
+        await box.query(conditions).order(AssetObjectBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   AssetDbModel modelFromJson(Map<String, dynamic> json) => AssetDbModel.fromJson(json);
 
   @override

--- a/lib/core/databases/adapters/objectbox/preferences_box.dart
+++ b/lib/core/databases/adapters/objectbox/preferences_box.dart
@@ -36,6 +36,16 @@ class PreferencesBox extends BaseBox<PreferenceObjectBox, PreferenceDbModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<PreferenceObjectBox> conditions = PreferenceObjectBox_.permanentlyDeletedAt.notNull();
+    List<PreferenceObjectBox> result =
+        await box.query(conditions).order(PreferenceObjectBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   PreferenceDbModel modelFromJson(Map<String, dynamic> json) => PreferenceDbModel.fromJson(json);
 
   @override

--- a/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
+++ b/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/databases/adapters/objectbox/base_box.dart';
 import 'package:storypad/core/databases/adapters/objectbox/entities.dart';
@@ -42,27 +41,47 @@ class RelaxSoundMixesBox extends BaseBox<RelaxSoundMixBox, RelaxSoundMixModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<RelaxSoundMixBox> conditions = RelaxSoundMixBox_.permanentlyDeletedAt.notNull();
+    List<RelaxSoundMixBox> result =
+        await box.query(conditions).order(RelaxSoundMixBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   RelaxSoundMixModel modelFromJson(Map<String, dynamic> json) {
     return RelaxSoundMixModel.fromJson(json);
   }
 
   @override
-  Future<List<RelaxSoundMixModel>> objectsToModels(List<RelaxSoundMixBox> objects, [Map<String, dynamic>? options]) {
-    return compute(_objectsToModels, {'objects': objects, 'options': options});
+  Future<List<RelaxSoundMixModel>> objectsToModels(List<RelaxSoundMixBox> objects,
+      [Map<String, dynamic>? options]) async {
+    return _objectsToModels({'objects': objects, 'options': options});
   }
 
   @override
-  Future<List<RelaxSoundMixBox>> modelsToObjects(List<RelaxSoundMixModel> models, [Map<String, dynamic>? options]) {
-    return compute(_modelsToObjects, {'models': models, 'options': options});
+  Future<List<RelaxSoundMixBox>> modelsToObjects(
+    List<RelaxSoundMixModel> models, [
+    Map<String, dynamic>? options,
+  ]) async {
+    return _modelsToObjects({'models': models, 'options': options});
   }
 
   @override
-  Future<RelaxSoundMixBox> modelToObject(RelaxSoundMixModel model, [Map<String, dynamic>? options]) {
-    return compute(_modelToObject, {'model': model, 'options': options});
+  Future<RelaxSoundMixBox> modelToObject(
+    RelaxSoundMixModel model, [
+    Map<String, dynamic>? options,
+  ]) async {
+    return _modelToObject({'model': model, 'options': options});
   }
 
   @override
-  Future<RelaxSoundMixModel> objectToModel(RelaxSoundMixBox object, [Map<String, dynamic>? options]) {
-    return compute(_objectToModel, {'object': object, 'options': options});
+  Future<RelaxSoundMixModel> objectToModel(
+    RelaxSoundMixBox object, [
+    Map<String, dynamic>? options,
+  ]) async {
+    return _objectToModel({'object': object, 'options': options});
   }
 }

--- a/lib/core/databases/adapters/objectbox/stories_box.dart
+++ b/lib/core/databases/adapters/objectbox/stories_box.dart
@@ -202,6 +202,16 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<StoryObjectBox> conditions = StoryObjectBox_.permanentlyDeletedAt.notNull();
+    List<StoryObjectBox> result =
+        await box.query(conditions).order(StoryObjectBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   StoryDbModel modelFromJson(Map<String, dynamic> json) {
     /// Migrate to v2, mostly from backup file. For DB level check: [StoriesBox#migrateDataToV2]
     if (json['version'] == 1) {

--- a/lib/core/databases/adapters/objectbox/tags_box.dart
+++ b/lib/core/databases/adapters/objectbox/tags_box.dart
@@ -68,6 +68,16 @@ class TagsBox extends BaseBox<TagObjectBox, TagDbModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<TagObjectBox> conditions = TagObjectBox_.permanentlyDeletedAt.notNull();
+    List<TagObjectBox> result =
+        await box.query(conditions).order(TagObjectBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   TagDbModel modelFromJson(Map<String, dynamic> json) {
     return TagDbModel.fromJson(json);
   }

--- a/lib/core/databases/adapters/objectbox/templates_box.dart
+++ b/lib/core/databases/adapters/objectbox/templates_box.dart
@@ -44,6 +44,16 @@ class TemplatesBox extends BaseBox<TemplateObjectBox, TemplateDbModel> {
   }
 
   @override
+  Future<Map<String, int>> getDeletedRecords() async {
+    Condition<TemplateObjectBox> conditions = TemplateObjectBox_.permanentlyDeletedAt.notNull();
+    List<TemplateObjectBox> result =
+        await box.query(conditions).order(TemplateObjectBox_.id, flags: Order.descending).build().findAsync();
+    return {
+      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
+    };
+  }
+
+  @override
   TemplateDbModel modelFromJson(Map<String, dynamic> json) {
     return TemplateDbModel.fromJson(json);
   }

--- a/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
+++ b/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
@@ -87,4 +87,9 @@ class BaseSqliteDbAdapter extends BaseDbAdapter {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<Map<String, int>> getDeletedRecords() {
+    throw UnimplementedError();
+  }
 }

--- a/lib/core/databases/models/relax_sound_model.g.dart
+++ b/lib/core/databases/models/relax_sound_model.g.dart
@@ -30,8 +30,7 @@ class _$RelaxSoundModelCWProxyImpl implements _$RelaxSoundModelCWProxy {
   final RelaxSoundModel _value;
 
   @override
-  RelaxSoundModel soundUrlPath(String soundUrlPath) =>
-      this(soundUrlPath: soundUrlPath);
+  RelaxSoundModel soundUrlPath(String soundUrlPath) => this(soundUrlPath: soundUrlPath);
 
   @override
   RelaxSoundModel volume(double volume) => this(volume: volume);
@@ -71,14 +70,12 @@ extension $RelaxSoundModelCopyWith on RelaxSoundModel {
 // JsonSerializableGenerator
 // **************************************************************************
 
-RelaxSoundModel _$RelaxSoundModelFromJson(Map<String, dynamic> json) =>
-    RelaxSoundModel(
+RelaxSoundModel _$RelaxSoundModelFromJson(Map<String, dynamic> json) => RelaxSoundModel(
       soundUrlPath: json['sound_url_path'] as String,
       volume: (json['volume'] as num).toDouble(),
     );
 
-Map<String, dynamic> _$RelaxSoundModelToJson(RelaxSoundModel instance) =>
-    <String, dynamic>{
+Map<String, dynamic> _$RelaxSoundModelToJson(RelaxSoundModel instance) => <String, dynamic>{
       'sound_url_path': instance.soundUrlPath,
       'volume': instance.volume,
     };

--- a/lib/core/objects/backup_object.dart
+++ b/lib/core/objects/backup_object.dart
@@ -4,6 +4,15 @@ import 'package:storypad/core/objects/device_info_object.dart';
 class BackupObject {
   final Map<String, dynamic> tables;
   final BackupFileObject fileInfo;
+
+  // { "table_name": {id: delete_at} }
+  //
+  // Example:
+  // {
+  //   "stories": {...},
+  //   "tags": {...},
+  // };
+  final Map<String, Map<String, int>>? deletedRecords;
   final int version;
 
   int? originalFileSize;
@@ -14,14 +23,29 @@ class BackupObject {
 
   BackupObject({
     required this.tables,
+    required this.deletedRecords,
     required this.fileInfo,
     this.version = currentVersion,
   });
 
   static BackupObject fromContents(Map<String, dynamic> contents) {
+    Map<String, Map<String, int>>? deletedRecords;
+
+    if (contents['deleted_records'] is Map) {
+      deletedRecords = (contents['deleted_records'] as Map<dynamic, dynamic>?)?.map(
+        (key, innerMap) => MapEntry(
+          key.toString(),
+          (innerMap as Map<dynamic, dynamic>).map(
+            (k, v) => MapEntry(k.toString(), v as int),
+          ),
+        ),
+      );
+    }
+
     return BackupObject(
       version: int.tryParse(contents['version'].toString()) ?? currentVersion,
       tables: contents['tables'],
+      deletedRecords: deletedRecords,
       fileInfo: BackupFileObject(
         createdAt: DateTime.parse(contents['meta_data']['created_at']),
         device: DeviceInfoObject(
@@ -36,6 +60,7 @@ class BackupObject {
     return {
       'version': version,
       'tables': tables,
+      'deleted_records': deletedRecords,
       'meta_data': {
         'device_model': fileInfo.device.model,
         'device_id': fileInfo.device.id,

--- a/lib/core/repositories/backup_repository.dart
+++ b/lib/core/repositories/backup_repository.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:storypad/core/databases/adapters/base_db_adapter.dart';
 import 'package:storypad/core/databases/models/asset_db_model.dart';
 import 'package:storypad/core/databases/models/preference_db_model.dart';
+import 'package:storypad/core/databases/models/relex_sound_mix_model.dart';
 import 'package:storypad/core/databases/models/story_db_model.dart';
 import 'package:storypad/core/databases/models/tag_db_model.dart';
 import 'package:storypad/core/databases/models/template_db_model.dart';
@@ -25,6 +26,7 @@ class BackupRepository {
     TagDbModel.db,
     TemplateDbModel.db,
     AssetDbModel.db,
+    RelaxSoundMixModel.db,
   ];
 
   final BackupImagesUploaderService step1ImagesUploader;

--- a/lib/core/services/audio_player_service.dart
+++ b/lib/core/services/audio_player_service.dart
@@ -9,7 +9,7 @@ class AudioPlayerService {
   final String urlPath;
   final void Function(PlayerState state) onStateChanged;
 
-  late double _volumn = _player.volume;
+  late double _volume = _player.volume;
 
   AudioPlayerService({
     required this.urlPath,
@@ -28,9 +28,9 @@ class AudioPlayerService {
   Completer<bool>? _setupCompleter;
   String? _downloadUrl;
 
-  double getVolume() => _volumn;
+  double getVolume() => _volume;
   void setVolume(double volume) {
-    _volumn = volume;
+    _volume = volume;
     _player.setVolume(volume);
   }
 

--- a/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
+++ b/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
@@ -13,15 +13,27 @@ class BackupDatabasesToBackupObjectService {
   }) async {
     debugPrint('BackupDatabasesToBackupObjectService#constructBackup');
     Map<String, dynamic> tables = await _constructTables(databases);
+    Map<String, Map<String, int>> deletedRecords = await _constructDeletedRecords(databases);
     debugPrint('BackupDatabasesToBackupObjectService#constructBackup ${tables.keys}');
 
     return BackupObject(
       tables: tables,
+      deletedRecords: deletedRecords,
       fileInfo: BackupFileObject(
         createdAt: lastUpdatedAt,
         device: kDeviceInfo,
       ),
     );
+  }
+
+  static Future<Map<String, Map<String, int>>> _constructDeletedRecords(List<BaseDbAdapter> databases) async {
+    Map<String, Map<String, int>> tables = {};
+
+    for (BaseDbAdapter db in databases) {
+      tables[db.tableName] = await db.getDeletedRecords();
+    }
+
+    return tables;
   }
 
   static Future<Map<String, dynamic>> _constructTables(List<BaseDbAdapter> databases) async {

--- a/lib/initializers/database_initializer.dart
+++ b/lib/initializers/database_initializer.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
-
 import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/databases/models/asset_db_model.dart';
 import 'package:storypad/core/databases/models/preference_db_model.dart';
+import 'package:storypad/core/databases/models/relex_sound_mix_model.dart';
 import 'package:storypad/core/databases/models/story_db_model.dart';
 import 'package:storypad/core/databases/models/tag_db_model.dart';
 import 'package:storypad/core/databases/models/template_db_model.dart';
@@ -15,6 +15,7 @@ class DatabaseInitializer {
     await TemplateDbModel.db.initilize();
     await PreferenceDbModel.db.initilize();
     await AssetDbModel.db.initilize();
+    await RelaxSoundMixModel.db.initilize();
 
     await migrateData();
   }

--- a/lib/providers/backup_provider.dart
+++ b/lib/providers/backup_provider.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -82,7 +85,11 @@ class BackupProvider extends ChangeNotifier {
     notifyListeners();
 
     if (readyToSynced) {
-      await _syncBackupAcrossDevices(currentUser!.email);
+      await runZonedGuarded(() async {
+        await _syncBackupAcrossDevices(currentUser!.email).timeout(const Duration(minutes: 3));
+      }, (error, stack) {
+        FirebaseCrashlytics.instance.recordError(error, stack, reason: 'Uncaught in zone');
+      });
     }
 
     _syncing = false;

--- a/lib/providers/relax_sounds_provider.dart
+++ b/lib/providers/relax_sounds_provider.dart
@@ -53,8 +53,8 @@ class RelaxSoundsProvider extends ChangeNotifier with DebounchedCallback {
 
   bool isSoundSelected(RelaxSoundObject sound) => audioPlayersService.exist(sound.soundUrlPath);
   double? getVolume(RelaxSoundObject sound) => audioPlayersService.getVolume(sound.soundUrlPath);
-  void setVolumn(RelaxSoundObject sound, double volumn) {
-    audioPlayersService.setVolume(sound.soundUrlPath, volumn);
+  void setVolumn(RelaxSoundObject sound, double volume) {
+    audioPlayersService.setVolume(sound.soundUrlPath, volume);
     notifyListeners();
 
     refreshCanSaveMix();

--- a/lib/views/backups/show/show_backup_content.dart
+++ b/lib/views/backups/show/show_backup_content.dart
@@ -77,6 +77,10 @@ class _ShowBackupContent extends StatelessWidget {
               leadingIconData = SpIcons.lightBulb;
               translateTabledName = tr("add_ons.templates.title");
               break;
+            case 'relax_sound_mixes':
+              leadingIconData = SpIcons.musicNote;
+              translateTabledName = tr("general.sound_mixes");
+              break;
             default:
               leadingIconData = SpIcons.table;
               translateTabledName = table.key;

--- a/lib/views/relax_sounds/relax_sounds_view_model.dart
+++ b/lib/views/relax_sounds/relax_sounds_view_model.dart
@@ -39,7 +39,7 @@ class RelaxSoundsViewModel extends ChangeNotifier with DisposeAwareMixin {
       ));
     }
 
-    // save to existing mix with different volumn when exist.
+    // save to existing mix with different volume when exist.
     RelaxSoundMixModel? existingMix = await provider.findExistingMix(ignoreVolume: true);
     await RelaxSoundMixModel.db.set(
       RelaxSoundMixModel(

--- a/test/core/objects/backup_object_test.dart
+++ b/test/core/objects/backup_object_test.dart
@@ -25,6 +25,7 @@ void main() {
         tables: testTables,
         fileInfo: testFileInfo,
         version: 2,
+        deletedRecords: {},
       );
 
       expect(backupObject.version, 2);
@@ -36,6 +37,7 @@ void main() {
       final backupObject = BackupObject(
         tables: testTables,
         fileInfo: testFileInfo,
+        deletedRecords: {},
       );
 
       expect(backupObject.version, BackupObject.currentVersion);
@@ -46,6 +48,7 @@ void main() {
         tables: testTables,
         fileInfo: testFileInfo,
         version: 1,
+        deletedRecords: {},
       );
 
       final contents = backupObject.toContents();


### PR DESCRIPTION
When a device deletes a record, previously, other devices still have the record. To fix this, we backup the deleted record to Google Drive as well. To keep the backup file lightweight, we only backup the ID & deleted at.

Deleted data is still kept within the device for potential restoration.