### PR TITLE
Simplify syncing delete records

### DIFF
--- a/lib/core/databases/adapters/base_db_adapter.dart
+++ b/lib/core/databases/adapters/base_db_adapter.dart
@@ -52,7 +52,7 @@ abstract class BaseDbAdapter<T extends BaseDbModel> {
   bool hasDeleted(int id);
 
   // id: deleted_at
-  Future<Map<String, int>> getDeletedRecords();
+  Future<Map<String, int>> getDeletedRecordByIds();
 
   T modelFromJson(Map<String, dynamic> json);
 

--- a/lib/core/databases/adapters/base_db_adapter.dart
+++ b/lib/core/databases/adapters/base_db_adapter.dart
@@ -16,6 +16,7 @@ abstract class BaseDbAdapter<T extends BaseDbModel> {
   Future<CollectionDbModel<T>?> where({
     Map<String, dynamic>? filters,
     Map<String, dynamic>? options,
+    bool returnDeleted = false,
   });
 
   Future<T?> touch(
@@ -50,9 +51,6 @@ abstract class BaseDbAdapter<T extends BaseDbModel> {
   });
 
   bool hasDeleted(int id);
-
-  // id: deleted_at
-  Future<Map<String, int>> getDeletedRecordByIds();
 
   T modelFromJson(Map<String, dynamic> json);
 

--- a/lib/core/databases/adapters/objectbox/assets_box.dart
+++ b/lib/core/databases/adapters/objectbox/assets_box.dart
@@ -24,24 +24,26 @@ class AssetsBox extends BaseBox<AssetObjectBox, AssetDbModel> {
   }
 
   @override
-  QueryBuilder<AssetObjectBox> buildQuery({Map<String, dynamic>? filters}) {
-    Condition<AssetObjectBox> conditions =
-        AssetObjectBox_.id.notNull().and(AssetObjectBox_.permanentlyDeletedAt.isNull());
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<AssetObjectBox> conditions = AssetObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(AssetObjectBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
+  }
+
+  @override
+  QueryBuilder<AssetObjectBox> buildQuery({
+    Map<String, dynamic>? filters,
+    bool returnDeleted = false,
+  }) {
+    Condition<AssetObjectBox> conditions = AssetObjectBox_.id.notNull();
+    if (!returnDeleted) conditions = conditions.and(AssetObjectBox_.permanentlyDeletedAt.isNull());
 
     QueryBuilder<AssetObjectBox> queryBuilder = box.query(conditions);
     queryBuilder = queryBuilder.order(AssetObjectBox_.id, flags: Order.descending);
 
     return queryBuilder;
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    Condition<AssetObjectBox> conditions = AssetObjectBox_.permanentlyDeletedAt.notNull();
-    List<AssetObjectBox> result =
-        await box.query(conditions).order(AssetObjectBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
   }
 
   @override

--- a/lib/core/databases/adapters/objectbox/assets_box.dart
+++ b/lib/core/databases/adapters/objectbox/assets_box.dart
@@ -35,7 +35,7 @@ class AssetsBox extends BaseBox<AssetObjectBox, AssetDbModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
+  Future<Map<String, int>> getDeletedRecordByIds() async {
     Condition<AssetObjectBox> conditions = AssetObjectBox_.permanentlyDeletedAt.notNull();
     List<AssetObjectBox> result =
         await box.query(conditions).order(AssetObjectBox_.id, flags: Order.descending).build().findAsync();

--- a/lib/core/databases/adapters/objectbox/base_box.dart
+++ b/lib/core/databases/adapters/objectbox/base_box.dart
@@ -21,6 +21,7 @@ abstract class BaseBox<B extends BaseObjectBox, T extends BaseDbModel> extends B
     return _box!;
   }
 
+  Future<void> cleanupOldDeletedRecords();
   Future<B> modelToObject(T model, [Map<String, dynamic>? options]);
   Future<List<B>> modelsToObjects(List<T> models, [Map<String, dynamic>? options]);
 
@@ -40,6 +41,8 @@ abstract class BaseBox<B extends BaseObjectBox, T extends BaseDbModel> extends B
       directory: directory.path,
       macosApplicationGroup: '24KJ877SZ9',
     );
+
+    await cleanupOldDeletedRecords();
   }
 
   @override
@@ -63,6 +66,7 @@ abstract class BaseBox<B extends BaseObjectBox, T extends BaseDbModel> extends B
 
   QueryBuilder<B> buildQuery({
     Map<String, dynamic>? filters,
+    bool returnDeleted = false,
   });
 
   @override
@@ -79,6 +83,7 @@ abstract class BaseBox<B extends BaseObjectBox, T extends BaseDbModel> extends B
   Future<CollectionDbModel<T>?> where({
     Map<String, dynamic>? filters,
     Map<String, dynamic>? options,
+    bool returnDeleted = false,
   }) async {
     debugPrint("Triggering $tableName#where 🍎");
 

--- a/lib/core/databases/adapters/objectbox/preferences_box.dart
+++ b/lib/core/databases/adapters/objectbox/preferences_box.dart
@@ -36,7 +36,7 @@ class PreferencesBox extends BaseBox<PreferenceObjectBox, PreferenceDbModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
+  Future<Map<String, int>> getDeletedRecordByIds() async {
     Condition<PreferenceObjectBox> conditions = PreferenceObjectBox_.permanentlyDeletedAt.notNull();
     List<PreferenceObjectBox> result =
         await box.query(conditions).order(PreferenceObjectBox_.id, flags: Order.descending).build().findAsync();

--- a/lib/core/databases/adapters/objectbox/preferences_box.dart
+++ b/lib/core/databases/adapters/objectbox/preferences_box.dart
@@ -29,20 +29,22 @@ class PreferencesBox extends BaseBox<PreferenceObjectBox, PreferenceDbModel> {
   }
 
   @override
-  QueryBuilder<PreferenceObjectBox> buildQuery({Map<String, dynamic>? filters}) {
-    Condition<PreferenceObjectBox> conditions =
-        PreferenceObjectBox_.id.notNull().and(PreferenceObjectBox_.permanentlyDeletedAt.isNull());
-    return box.query(conditions);
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<PreferenceObjectBox> conditions = PreferenceObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(PreferenceObjectBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    Condition<PreferenceObjectBox> conditions = PreferenceObjectBox_.permanentlyDeletedAt.notNull();
-    List<PreferenceObjectBox> result =
-        await box.query(conditions).order(PreferenceObjectBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
+  QueryBuilder<PreferenceObjectBox> buildQuery({
+    Map<String, dynamic>? filters,
+    bool returnDeleted = false,
+  }) {
+    Condition<PreferenceObjectBox> conditions = PreferenceObjectBox_.id.notNull();
+    if (!returnDeleted) conditions = conditions.and(PreferenceObjectBox_.permanentlyDeletedAt.isNull());
+    return box.query(conditions);
   }
 
   @override

--- a/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
+++ b/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
@@ -42,7 +42,7 @@ class RelaxSoundMixesBox extends BaseBox<RelaxSoundMixBox, RelaxSoundMixModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
+  Future<Map<String, int>> getDeletedRecordByIds() async {
     Condition<RelaxSoundMixBox> conditions = RelaxSoundMixBox_.permanentlyDeletedAt.notNull();
     List<RelaxSoundMixBox> result =
         await box.query(conditions).order(RelaxSoundMixBox_.id, flags: Order.descending).build().findAsync();

--- a/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
+++ b/lib/core/databases/adapters/objectbox/relax_sound_mixes_box.dart
@@ -29,26 +29,26 @@ class RelaxSoundMixesBox extends BaseBox<RelaxSoundMixBox, RelaxSoundMixModel> {
   }
 
   @override
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<RelaxSoundMixBox> conditions = RelaxSoundMixBox_.permanentlyDeletedAt
+        .notNull()
+        .and(RelaxSoundMixBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
+  }
+
+  @override
   QueryBuilder<RelaxSoundMixBox> buildQuery({
     Map<String, dynamic>? filters,
+    bool returnDeleted = false,
   }) {
-    Condition<RelaxSoundMixBox> conditions =
-        RelaxSoundMixBox_.id.notNull().and(RelaxSoundMixBox_.permanentlyDeletedAt.isNull());
+    Condition<RelaxSoundMixBox> conditions = RelaxSoundMixBox_.id.notNull();
+    if (!returnDeleted) conditions = conditions.and(RelaxSoundMixBox_.permanentlyDeletedAt.isNull());
 
     QueryBuilder<RelaxSoundMixBox> queryBuilder = box.query(conditions);
     queryBuilder.order(RelaxSoundMixBox_.index);
 
     return queryBuilder;
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    Condition<RelaxSoundMixBox> conditions = RelaxSoundMixBox_.permanentlyDeletedAt.notNull();
-    List<RelaxSoundMixBox> result =
-        await box.query(conditions).order(RelaxSoundMixBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
   }
 
   @override

--- a/lib/core/databases/adapters/objectbox/stories_box.dart
+++ b/lib/core/databases/adapters/objectbox/stories_box.dart
@@ -202,8 +202,11 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
-    Condition<StoryObjectBox> conditions = StoryObjectBox_.permanentlyDeletedAt.notNull();
+  Future<Map<String, int>> getDeletedRecordByIds() async {
+    final sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    final conditions =
+        StoryObjectBox_.permanentlyDeletedAt.notNull().and(StoryObjectBox_.updatedAt.greaterOrEqualDate(sevenDaysAgo));
+
     List<StoryObjectBox> result =
         await box.query(conditions).order(StoryObjectBox_.id, flags: Order.descending).build().findAsync();
     return {

--- a/lib/core/databases/adapters/objectbox/stories_box.dart
+++ b/lib/core/databases/adapters/objectbox/stories_box.dart
@@ -55,6 +55,15 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
     return object?.updatedAt;
   }
 
+  @override
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<StoryObjectBox> conditions = StoryObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(StoryObjectBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
+  }
+
   Future<Map<int, int>> getStoryCountsByYear({
     Map<String, dynamic>? filters,
   }) async {
@@ -134,7 +143,10 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
   }
 
   @override
-  QueryBuilder<StoryObjectBox> buildQuery({Map<String, dynamic>? filters}) {
+  QueryBuilder<StoryObjectBox> buildQuery({
+    Map<String, dynamic>? filters,
+    bool returnDeleted = false,
+  }) {
     String? query = filters?["query"];
     String? type = filters?["type"];
     List<String>? types = filters?["types"];
@@ -152,9 +164,9 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
     List<int>? selectedYears = filters?["selected_years"];
     List<int>? yearsRange = filters?["years_range"];
 
-    Condition<StoryObjectBox>? conditions =
-        StoryObjectBox_.id.notNull().and(StoryObjectBox_.permanentlyDeletedAt.isNull());
+    Condition<StoryObjectBox>? conditions = StoryObjectBox_.id.notNull();
 
+    if (!returnDeleted) conditions = conditions.and(StoryObjectBox_.permanentlyDeletedAt.isNull());
     if (tag != null) conditions = conditions.and(StoryObjectBox_.tags.containsElement(tag.toString()));
     if (template != null) conditions = conditions.and(StoryObjectBox_.templateId.equals(template));
     if (asset != null) conditions = conditions.and(StoryObjectBox_.assets.equals(asset));
@@ -199,19 +211,6 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
       ..order(StoryObjectBox_.minute, flags: order ?? Order.descending);
 
     return queryBuilder;
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    final sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
-    final conditions =
-        StoryObjectBox_.permanentlyDeletedAt.notNull().and(StoryObjectBox_.updatedAt.greaterOrEqualDate(sevenDaysAgo));
-
-    List<StoryObjectBox> result =
-        await box.query(conditions).order(StoryObjectBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
   }
 
   @override

--- a/lib/core/databases/adapters/objectbox/tags_box.dart
+++ b/lib/core/databases/adapters/objectbox/tags_box.dart
@@ -68,7 +68,7 @@ class TagsBox extends BaseBox<TagObjectBox, TagDbModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
+  Future<Map<String, int>> getDeletedRecordByIds() async {
     Condition<TagObjectBox> conditions = TagObjectBox_.permanentlyDeletedAt.notNull();
     List<TagObjectBox> result =
         await box.query(conditions).order(TagObjectBox_.id, flags: Order.descending).build().findAsync();

--- a/lib/core/databases/adapters/objectbox/tags_box.dart
+++ b/lib/core/databases/adapters/objectbox/tags_box.dart
@@ -34,9 +34,19 @@ class TagsBox extends BaseBox<TagObjectBox, TagDbModel> {
   }
 
   @override
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<TagObjectBox> conditions = TagObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(TagObjectBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
+  }
+
+  @override
   Future<CollectionDbModel<TagDbModel>?> where({
     Map<String, dynamic>? filters,
     Map<String, dynamic>? options,
+    bool returnDeleted = false,
   }) async {
     CollectionDbModel<TagDbModel>? result = await super.where(filters: filters);
     List<TagDbModel> items = result?.items ?? [];
@@ -56,25 +66,18 @@ class TagsBox extends BaseBox<TagObjectBox, TagDbModel> {
   @override
   QueryBuilder<TagObjectBox> buildQuery({
     Map<String, dynamic>? filters,
+    bool returnDeleted = false,
   }) {
     int? order = filters?["order"];
-    Condition<TagObjectBox> conditions = TagObjectBox_.id.notNull().and(TagObjectBox_.permanentlyDeletedAt.isNull());
+
+    Condition<TagObjectBox> conditions = TagObjectBox_.id.notNull();
+    if (!returnDeleted) conditions = conditions.and(TagObjectBox_.permanentlyDeletedAt.isNull());
 
     QueryBuilder<TagObjectBox> queryBuilder = box.query(conditions);
 
     queryBuilder.order(TagObjectBox_.index, flags: order ?? 0);
 
     return queryBuilder;
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    Condition<TagObjectBox> conditions = TagObjectBox_.permanentlyDeletedAt.notNull();
-    List<TagObjectBox> result =
-        await box.query(conditions).order(TagObjectBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
   }
 
   @override

--- a/lib/core/databases/adapters/objectbox/templates_box.dart
+++ b/lib/core/databases/adapters/objectbox/templates_box.dart
@@ -44,7 +44,7 @@ class TemplatesBox extends BaseBox<TemplateObjectBox, TemplateDbModel> {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() async {
+  Future<Map<String, int>> getDeletedRecordByIds() async {
     Condition<TemplateObjectBox> conditions = TemplateObjectBox_.permanentlyDeletedAt.notNull();
     List<TemplateObjectBox> result =
         await box.query(conditions).order(TemplateObjectBox_.id, flags: Order.descending).build().findAsync();

--- a/lib/core/databases/adapters/objectbox/templates_box.dart
+++ b/lib/core/databases/adapters/objectbox/templates_box.dart
@@ -29,28 +29,29 @@ class TemplatesBox extends BaseBox<TemplateObjectBox, TemplateDbModel> {
   }
 
   @override
+  Future<void> cleanupOldDeletedRecords() async {
+    DateTime sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    Condition<TemplateObjectBox> conditions = TemplateObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(TemplateObjectBox_.permanentlyDeletedAt.lessOrEqualDate(sevenDaysAgo));
+    await box.query(conditions).build().removeAsync();
+  }
+
+  @override
   QueryBuilder<TemplateObjectBox> buildQuery({
     Map<String, dynamic>? filters,
+    bool returnDeleted = false,
   }) {
     int? order = filters?["order"];
-    Condition<TemplateObjectBox> conditions =
-        TemplateObjectBox_.id.notNull().and(TemplateObjectBox_.permanentlyDeletedAt.isNull());
+
+    Condition<TemplateObjectBox> conditions = TemplateObjectBox_.id.notNull();
+    if (!returnDeleted) conditions = conditions.and(TemplateObjectBox_.permanentlyDeletedAt.isNull());
 
     QueryBuilder<TemplateObjectBox> queryBuilder = box.query(conditions);
 
     queryBuilder.order(TemplateObjectBox_.index, flags: order ?? 0);
 
     return queryBuilder;
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() async {
-    Condition<TemplateObjectBox> conditions = TemplateObjectBox_.permanentlyDeletedAt.notNull();
-    List<TemplateObjectBox> result =
-        await box.query(conditions).order(TemplateObjectBox_.id, flags: Order.descending).build().findAsync();
-    return {
-      for (final data in result) data.id.toString(): data.permanentlyDeletedAt!.millisecondsSinceEpoch,
-    };
   }
 
   @override

--- a/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
+++ b/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
@@ -90,7 +90,7 @@ class BaseSqliteDbAdapter extends BaseDbAdapter {
   }
 
   @override
-  Future<Map<String, int>> getDeletedRecords() {
+  Future<Map<String, int>> getDeletedRecordByIds() {
     throw UnimplementedError();
   }
 }

--- a/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
+++ b/lib/core/databases/adapters/sqlite/base_sqlite_db_adapter.dart
@@ -51,6 +51,7 @@ class BaseSqliteDbAdapter extends BaseDbAdapter {
   Future<CollectionDbModel<BaseDbModel>?> where({
     Map<String, dynamic>? filters,
     Map<String, dynamic>? options,
+    bool returnDeleted = false,
   }) {
     throw UnimplementedError();
   }
@@ -86,11 +87,6 @@ class BaseSqliteDbAdapter extends BaseDbAdapter {
     List<BaseDbModel> records, {
     bool runCallbacks = true,
   }) {
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<Map<String, int>> getDeletedRecordByIds() {
     throw UnimplementedError();
   }
 }

--- a/lib/core/databases/models/story_db_model.dart
+++ b/lib/core/databases/models/story_db_model.dart
@@ -114,14 +114,15 @@ class StoryDbModel extends BaseDbModel {
 
   bool get inBins => type == PathType.bins;
   bool get inArchives => type == PathType.archives;
+  bool get permanentlyDeleted => permanentlyDeletedAt != null;
 
   bool get editable => type == PathType.docs && !cloudViewing;
-  bool get putBackAble => (inBins || unarchivable) && !cloudViewing;
+  bool get putBackAble => (permanentlyDeleted || inBins || unarchivable) && !cloudViewing;
 
   bool get archivable => type == PathType.docs && !cloudViewing;
   bool get unarchivable => type == PathType.archives && !cloudViewing;
-  bool get canMoveToBin => !inBins && !cloudViewing;
-  bool get hardDeletable => inBins && !cloudViewing;
+  bool get canMoveToBin => !permanentlyDeleted && !inBins && !cloudViewing;
+  bool get hardDeletable => !permanentlyDeleted && inBins && !cloudViewing;
 
   int? get willBeRemovedInDays {
     if (movedToBinAt != null) {
@@ -157,6 +158,7 @@ class StoryDbModel extends BaseDbModel {
         type: PathType.docs,
         updatedAt: DateTime.now(),
         movedToBinAt: null,
+        permanentlyDeletedAt: null,
       ),
     );
   }

--- a/lib/core/objects/backup_object.dart
+++ b/lib/core/objects/backup_object.dart
@@ -5,14 +5,6 @@ class BackupObject {
   final Map<String, dynamic> tables;
   final BackupFileObject fileInfo;
 
-  // { "table_name": {id: delete_at} }
-  //
-  // Example:
-  // {
-  //   "stories": {...},
-  //   "tags": {...},
-  // };
-  final Map<String, Map<String, int>>? deletedRecords;
   final int version;
 
   int? originalFileSize;
@@ -23,29 +15,14 @@ class BackupObject {
 
   BackupObject({
     required this.tables,
-    required this.deletedRecords,
     required this.fileInfo,
     this.version = currentVersion,
   });
 
   static BackupObject fromContents(Map<String, dynamic> contents) {
-    Map<String, Map<String, int>>? deletedRecords;
-
-    if (contents['deleted_records'] is Map) {
-      deletedRecords = (contents['deleted_records'] as Map<dynamic, dynamic>?)?.map(
-        (key, innerMap) => MapEntry(
-          key.toString(),
-          (innerMap as Map<dynamic, dynamic>).map(
-            (k, v) => MapEntry(k.toString(), v as int),
-          ),
-        ),
-      );
-    }
-
     return BackupObject(
       version: int.tryParse(contents['version'].toString()) ?? currentVersion,
       tables: contents['tables'],
-      deletedRecords: deletedRecords,
       fileInfo: BackupFileObject(
         createdAt: DateTime.parse(contents['meta_data']['created_at']),
         device: DeviceInfoObject(
@@ -60,7 +37,6 @@ class BackupObject {
     return {
       'version': version,
       'tables': tables,
-      'deleted_records': deletedRecords,
       'meta_data': {
         'device_model': fileInfo.device.model,
         'device_id': fileInfo.device.id,

--- a/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
+++ b/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
@@ -13,12 +13,10 @@ class BackupDatabasesToBackupObjectService {
   }) async {
     debugPrint('BackupDatabasesToBackupObjectService#constructBackup');
     Map<String, dynamic> tables = await _constructTables(databases);
-    Map<String, Map<String, int>> deletedRecords = await _constructDeletedRecords(databases);
     debugPrint('BackupDatabasesToBackupObjectService#constructBackup ${tables.keys}');
 
     return BackupObject(
       tables: tables,
-      deletedRecords: deletedRecords,
       fileInfo: BackupFileObject(
         createdAt: lastUpdatedAt,
         device: kDeviceInfo,
@@ -26,21 +24,11 @@ class BackupDatabasesToBackupObjectService {
     );
   }
 
-  static Future<Map<String, Map<String, int>>> _constructDeletedRecords(List<BaseDbAdapter> databases) async {
-    Map<String, Map<String, int>> tables = {};
-
-    for (BaseDbAdapter db in databases) {
-      tables[db.tableName] = await db.getDeletedRecordByIds();
-    }
-
-    return tables;
-  }
-
   static Future<Map<String, dynamic>> _constructTables(List<BaseDbAdapter> databases) async {
     Map<String, CollectionDbModel<BaseDbModel>> tables = {};
 
     for (BaseDbAdapter db in databases) {
-      CollectionDbModel<BaseDbModel>? items = await db.where();
+      CollectionDbModel<BaseDbModel>? items = await db.where(returnDeleted: true);
       tables[db.tableName] = items ?? CollectionDbModel(items: []);
     }
 

--- a/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
+++ b/lib/core/services/backup_sync_steps/utils/backup_databases_to_backup_object_service.dart
@@ -30,7 +30,7 @@ class BackupDatabasesToBackupObjectService {
     Map<String, Map<String, int>> tables = {};
 
     for (BaseDbAdapter db in databases) {
-      tables[db.tableName] = await db.getDeletedRecords();
+      tables[db.tableName] = await db.getDeletedRecordByIds();
     }
 
     return tables;

--- a/lib/core/services/backup_sync_steps/utils/restore_backup_service.dart
+++ b/lib/core/services/backup_sync_steps/utils/restore_backup_service.dart
@@ -26,60 +26,25 @@ class RestoreBackupService {
 
     for (BaseDbAdapter db in BackupRepository.databases) {
       List<BaseDbModel>? items = datas[db.tableName];
-      Map<String, int>? deletedAtRecordsById = backup.deletedRecords?[db.tableName];
 
-      // 1. delete records that has been deleted from other app.
-      if (deletedAtRecordsById != null) {
-        for (var entry in deletedAtRecordsById.entries) {
-          int? id = int.tryParse(entry.key);
-          if (id == null) continue;
-
-          DateTime deletedAtOnOtherDevice = DateTime.fromMillisecondsSinceEpoch(entry.value);
-          BaseDbModel? existingRecord = await db.find(id, returnDeleted: true);
-
-          if (existingRecord != null) {
-            bool hasUpdateAfterDeleteFromOtherDevice = existingRecord.permanentlyDeletedAt == null &&
-                existingRecord.updatedAt != null &&
-                existingRecord.updatedAt!.isAfter(deletedAtOnOtherDevice);
-
-            if (hasUpdateAfterDeleteFromOtherDevice) {
-              await db.delete(id, runCallbacks: false, deletedAt: deletedAtOnOtherDevice);
-              changesCount++;
-            }
-          }
-        }
-      }
-
-      // 2. restore records / prepare records for next backup.
       if (items != null) {
         for (BaseDbModel newRecord in items) {
           BaseDbModel? existingRecord = await db.find(newRecord.id, returnDeleted: true);
-          bool deletedOnThisDevice = existingRecord?.permanentlyDeletedAt != null;
 
-          if (deletedOnThisDevice) {
-            if (newRecord.updatedAt != null) {
-              bool hasUpdateAfterDelete = newRecord.updatedAt!.isAfter(existingRecord!.permanentlyDeletedAt!);
-              if (hasUpdateAfterDelete) {
-                await db.set(newRecord, runCallbacks: false);
-                changesCount++;
-              }
-            }
-          } else if (existingRecord != null) {
-            if (existingRecord.updatedAt != null && newRecord.updatedAt != null) {
-              bool newContent = existingRecord.updatedAt!.isBefore(newRecord.updatedAt!);
-              bool unSyncContent = existingRecord.updatedAt!.isAfter(newRecord.updatedAt!);
+          if (existingRecord != null && existingRecord.updatedAt != null && newRecord.updatedAt != null) {
+            bool backupHasNewerContent = existingRecord.updatedAt!.isBefore(newRecord.updatedAt!);
+            bool deviceHasNewerContent = existingRecord.updatedAt!.isAfter(newRecord.updatedAt!);
 
-              if (newContent) {
-                await db.set(newRecord, runCallbacks: false);
-                changesCount++;
-              } else if (unSyncContent) {
-                // Update `updatedAt` to mark the record as unsynced, ensuring the backup provider picks it up later.
-                // This prevents the app from incorrectly assuming the database is fully synced after restoration.
-                await db.touch(existingRecord, runCallbacks: false);
-              } else {
-                // this case, contents may be deleted & unchanged on other device.
-                // so we can ignore them.
-              }
+            if (backupHasNewerContent) {
+              await db.set(newRecord, runCallbacks: false);
+              changesCount++;
+            } else if (deviceHasNewerContent) {
+              // Update `updatedAt` to mark the record as unsynced, ensuring the backup provider picks it up later.
+              // This prevents the app from incorrectly assuming the database is fully synced after restoration.
+              await db.touch(existingRecord, runCallbacks: false);
+            } else {
+              // this case, contents may be deleted & unchanged on other device.
+              // so we can ignore them.
             }
           } else {
             await db.set(newRecord, runCallbacks: false);

--- a/lib/core/services/backup_sync_steps/utils/restore_backup_service.dart
+++ b/lib/core/services/backup_sync_steps/utils/restore_backup_service.dart
@@ -34,12 +34,16 @@ class RestoreBackupService {
           int? id = int.tryParse(entry.key);
           if (id == null) continue;
 
-          DateTime deletedAt = DateTime.fromMillisecondsSinceEpoch(entry.value);
-          BaseDbModel? existingRecord = await db.find(id, returnDeleted: false);
+          DateTime deletedAtOnOtherDevice = DateTime.fromMillisecondsSinceEpoch(entry.value);
+          BaseDbModel? existingRecord = await db.find(id, returnDeleted: true);
 
           if (existingRecord != null) {
-            if (existingRecord.updatedAt == null || existingRecord.updatedAt!.isBefore(deletedAt)) {
-              await db.delete(id, runCallbacks: false, deletedAt: deletedAt);
+            bool hasUpdateAfterDeleteFromOtherDevice = existingRecord.permanentlyDeletedAt == null &&
+                existingRecord.updatedAt != null &&
+                existingRecord.updatedAt!.isAfter(deletedAtOnOtherDevice);
+
+            if (hasUpdateAfterDeleteFromOtherDevice) {
+              await db.delete(id, runCallbacks: false, deletedAt: deletedAtOnOtherDevice);
               changesCount++;
             }
           }
@@ -50,11 +54,11 @@ class RestoreBackupService {
       if (items != null) {
         for (BaseDbModel newRecord in items) {
           BaseDbModel? existingRecord = await db.find(newRecord.id, returnDeleted: true);
+          bool deletedOnThisDevice = existingRecord?.permanentlyDeletedAt != null;
 
-          if (existingRecord?.permanentlyDeletedAt != null) {
+          if (deletedOnThisDevice) {
             if (newRecord.updatedAt != null) {
               bool hasUpdateAfterDelete = newRecord.updatedAt!.isAfter(existingRecord!.permanentlyDeletedAt!);
-
               if (hasUpdateAfterDelete) {
                 await db.set(newRecord, runCallbacks: false);
                 changesCount++;

--- a/lib/views/community/community_content.dart
+++ b/lib/views/community/community_content.dart
@@ -57,6 +57,7 @@ class _CommunityContent extends StatelessWidget {
           ListTile(
             leading: Icon(SpIcons.license),
             title: Text(tr("list_tile.licenses.title")),
+            onLongPress: () => const DeveloperOptionsRoute().push(context, rootNavigator: true),
             onTap: () {
               AnalyticsService.instance.logLicenseView();
               showLicensePage(

--- a/lib/views/community/community_view.dart
+++ b/lib/views/community/community_view.dart
@@ -6,6 +6,7 @@ import 'package:storypad/core/extensions/color_scheme_extension.dart';
 import 'package:storypad/core/services/analytics/analytics_service.dart';
 import 'package:storypad/core/services/remote_config/remote_config_service.dart';
 import 'package:storypad/core/services/url_opener_service.dart';
+import 'package:storypad/views/developer_options/developer_options_view.dart';
 import 'package:storypad/widgets/bottom_sheets/sp_share_app_bottom_sheet.dart';
 import 'package:storypad/widgets/sp_fade_in.dart';
 import 'package:storypad/widgets/sp_icons.dart';

--- a/lib/views/developer_options/developer_options_view.dart
+++ b/lib/views/developer_options/developer_options_view.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:storypad/views/developer_options/recently_deleted_records/recently_deleted_records_view.dart';
+import 'package:storypad/widgets/base_view/base_route.dart';
+import 'package:storypad/widgets/sp_icons.dart';
+
+class DeveloperOptionsRoute extends BaseRoute {
+  const DeveloperOptionsRoute();
+
+  @override
+  Widget buildPage(BuildContext context) => DeveloperOptionsView(params: this);
+}
+
+class DeveloperOptionsView extends StatelessWidget {
+  const DeveloperOptionsView({
+    super.key,
+    required this.params,
+  });
+
+  final DeveloperOptionsRoute params;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Developer Options"),
+      ),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: Icon(SpIcons.table),
+            title: const Text("Delete Records"),
+            subtitle: const Text(
+              "For safety, permanently deleted records are kept on your device for 7 days "
+              "(and are not backed up to the cloud). "
+              "To remove them immediately, clear the app cache.",
+            ),
+            trailing: const Icon(SpIcons.keyboardRight),
+            onTap: () => const RecentlyDeletedRecordsRoute().push(context),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/developer_options/recently_deleted_records/recently_deleted_records_content.dart
+++ b/lib/views/developer_options/recently_deleted_records/recently_deleted_records_content.dart
@@ -1,0 +1,27 @@
+part of 'recently_deleted_records_view.dart';
+
+class _RecentlyDeletedRecordsContent extends StatelessWidget {
+  const _RecentlyDeletedRecordsContent(this.viewModel);
+
+  final RecentlyDeletedRecordsViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Deleted Records"),
+      ),
+      body: SpStoryListMultiEditWrapper(
+        disabled: true,
+        builder: (BuildContext context) {
+          return SpStoryList(
+            viewOnly: true,
+            stories: viewModel.deleteRecords,
+            onChanged: (_) => viewModel.load(),
+            onDeleted: () {},
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view.dart
+++ b/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view.dart
@@ -1,0 +1,35 @@
+import 'package:storypad/widgets/base_view/view_model_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:storypad/widgets/base_view/base_route.dart';
+import 'package:storypad/widgets/story_list/sp_story_list.dart';
+import 'package:storypad/widgets/story_list/sp_story_list_multi_edit_wrapper.dart';
+
+import 'recently_deleted_records_view_model.dart';
+
+part 'recently_deleted_records_content.dart';
+
+class RecentlyDeletedRecordsRoute extends BaseRoute {
+  const RecentlyDeletedRecordsRoute();
+
+  @override
+  Widget buildPage(BuildContext context) => RecentlyDeletedRecordsView(params: this);
+}
+
+class RecentlyDeletedRecordsView extends StatelessWidget {
+  const RecentlyDeletedRecordsView({
+    super.key,
+    required this.params,
+  });
+
+  final RecentlyDeletedRecordsRoute params;
+
+  @override
+  Widget build(BuildContext context) {
+    return ViewModelProvider<RecentlyDeletedRecordsViewModel>(
+      create: (context) => RecentlyDeletedRecordsViewModel(params: params),
+      builder: (context, viewModel, child) {
+        return _RecentlyDeletedRecordsContent(viewModel);
+      },
+    );
+  }
+}

--- a/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view_model.dart
+++ b/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view_model.dart
@@ -23,11 +23,7 @@ class RecentlyDeletedRecordsViewModel extends ChangeNotifier with DisposeAwareMi
   }
 
   Future<CollectionDbModel<StoryDbModel>?> getDeletedRecords() async {
-    final sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
-    final conditions = StoryObjectBox_.permanentlyDeletedAt
-        .notNull()
-        .and(StoryObjectBox_.updatedAt.greaterOrEqualDate(sevenDaysAgo))
-        .and(StoryObjectBox_.latestContent.notNull());
+    final conditions = StoryObjectBox_.permanentlyDeletedAt.notNull().and(StoryObjectBox_.latestContent.notNull());
 
     QueryBuilder<StoryObjectBox> queryBuilder = StoryDbModel.db.box.query(conditions);
 

--- a/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view_model.dart
+++ b/lib/views/developer_options/recently_deleted_records/recently_deleted_records_view_model.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:storypad/core/databases/adapters/objectbox/entities.dart';
+import 'package:storypad/core/databases/models/collection_db_model.dart';
+import 'package:storypad/core/databases/models/story_db_model.dart';
+import 'package:storypad/core/mixins/dispose_aware_mixin.dart';
+import 'package:storypad/objectbox.g.dart';
+import 'recently_deleted_records_view.dart';
+
+class RecentlyDeletedRecordsViewModel extends ChangeNotifier with DisposeAwareMixin {
+  final RecentlyDeletedRecordsRoute params;
+
+  RecentlyDeletedRecordsViewModel({
+    required this.params,
+  }) {
+    load();
+  }
+
+  CollectionDbModel<StoryDbModel>? deleteRecords;
+
+  Future<void> load() async {
+    deleteRecords = await getDeletedRecords();
+    notifyListeners();
+  }
+
+  Future<CollectionDbModel<StoryDbModel>?> getDeletedRecords() async {
+    final sevenDaysAgo = DateTime.now().subtract(const Duration(days: 7));
+    final conditions = StoryObjectBox_.permanentlyDeletedAt
+        .notNull()
+        .and(StoryObjectBox_.updatedAt.greaterOrEqualDate(sevenDaysAgo))
+        .and(StoryObjectBox_.latestContent.notNull());
+
+    QueryBuilder<StoryObjectBox> queryBuilder = StoryDbModel.db.box.query(conditions);
+
+    queryBuilder
+      ..order(StoryObjectBox_.year, flags: Order.descending)
+      ..order(StoryObjectBox_.month, flags: Order.descending)
+      ..order(StoryObjectBox_.day, flags: Order.descending)
+      ..order(StoryObjectBox_.hour, flags: Order.descending)
+      ..order(StoryObjectBox_.minute, flags: Order.descending);
+
+    Query<StoryObjectBox>? query = queryBuilder.build();
+    List<StoryObjectBox> objects = await query.findAsync();
+
+    List<StoryDbModel> docs = await StoryDbModel.db.objectsToModels(objects, {});
+    return CollectionDbModel<StoryDbModel>(items: docs);
+  }
+}

--- a/lib/views/templates/show/show_template_view_model.dart
+++ b/lib/views/templates/show/show_template_view_model.dart
@@ -7,6 +7,7 @@ import 'package:storypad/core/databases/models/template_db_model.dart';
 import 'package:storypad/core/mixins/debounched_callback.dart';
 import 'package:storypad/core/mixins/dispose_aware_mixin.dart';
 import 'package:storypad/core/objects/story_page_objects_map.dart';
+import 'package:storypad/views/home/home_view.dart';
 import 'package:storypad/views/stories/edit/edit_story_view.dart';
 import 'package:storypad/views/stories/local_widgets/base_story_view_model.dart';
 import 'package:storypad/views/templates/edit/edit_template_view.dart';
@@ -58,6 +59,9 @@ class ShowTemplateViewModel extends ChangeNotifier with DisposeAwareMixin, Debou
     ).push(context, rootNavigator: true);
 
     if (context.mounted && result is StoryDbModel) {
+      Future.delayed(const Duration(seconds: 1)).then((_) {
+        HomeView.reload(debugSource: '$runtimeType#useTemplate');
+      });
       Navigator.maybePop(context, result);
     }
   }

--- a/lib/views/templates/templates_content.dart
+++ b/lib/views/templates/templates_content.dart
@@ -40,6 +40,7 @@ class _TemplatesContent extends StatelessWidget {
     return ReorderableListView.builder(
       itemCount: templates.length,
       padding: EdgeInsets.only(
+        top: 8.0,
         left: MediaQuery.of(context).padding.left + 10.0,
         right: MediaQuery.of(context).padding.right + 10.0,
         bottom: MediaQuery.of(context).padding.bottom + 16.0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.15.2+414
+version: 2.15.3+415
 publish_to: none
 environment:
   sdk: ^3.5.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.15.3+415
+version: 2.15.3+416
 publish_to: none
 environment:
   sdk: ^3.5.4

--- a/test/core/objects/backup_object_test.dart
+++ b/test/core/objects/backup_object_test.dart
@@ -25,7 +25,6 @@ void main() {
         tables: testTables,
         fileInfo: testFileInfo,
         version: 2,
-        deletedRecords: {},
       );
 
       expect(backupObject.version, 2);
@@ -37,7 +36,6 @@ void main() {
       final backupObject = BackupObject(
         tables: testTables,
         fileInfo: testFileInfo,
-        deletedRecords: {},
       );
 
       expect(backupObject.version, BackupObject.currentVersion);
@@ -48,7 +46,6 @@ void main() {
         tables: testTables,
         fileInfo: testFileInfo,
         version: 1,
-        deletedRecords: {},
       );
 
       final contents = backupObject.toContents();


### PR DESCRIPTION
## Problem
Syncing active data to Google Drive is relatively straightforward, but handling deleted records introduces complexity.

For example:
- When a record is deleted on one device, how do other devices know to also remove it?
- If we choose to back up deleted records too, what happens if another device updates that record after deletion?
- Retaining deleted content can also lead to unnecessary growth in cloud storage usage.

This PR addresses these challenges by implementing a balanced approach that preserves sync integrity while keeping storage efficient.

## What's in this PR
- Sync deleted records to Google Drive: Other devices will detect these deletions and mark the corresponding local records as deleted.
- Conflict handling: If Device A deletes a record, but Device B updates it before receiving the deletion, Device A will receive the updated content — ensuring no data is accidentally lost.
- Automatic cleanup of deleted records: Deleted records older than 7 days are permanently removed from the cloud to keep backup size manageable.
- Recently deleted view (in developer options): Allows viewing and optionally restoring recently deleted records (within the 7-day window). This makes deletions safer and more recoverable for users.