### PR TITLE
Improve pages layout

### DIFF
--- a/lib/core/extensions/matrix_4_extension.dart
+++ b/lib/core/extensions/matrix_4_extension.dart
@@ -5,7 +5,7 @@ import 'package:vector_math/vector_math_64.dart' show Vector3;
 
 extension Matrix4Extension on Matrix4 {
   void spTranslate(
-    dynamic x, [
+    double x, [
     double y = 0.0,
     double z = 0.0,
   ]) {

--- a/lib/providers/device_preferences_provider.dart
+++ b/lib/providers/device_preferences_provider.dart
@@ -91,13 +91,20 @@ class DevicePreferencesProvider extends ChangeNotifier {
     );
   }
 
-  void toggleThemeMode(BuildContext context) {
+  void toggleThemeMode(
+    BuildContext context, {
+    Duration? delay,
+  }) async {
     if (themeMode == ThemeMode.system) {
       Brightness? brightness = View.maybeOf(context)?.platformDispatcher.platformBrightness;
       bool isDarkMode = brightness == Brightness.dark;
+
+      if (delay != null) await Future.delayed(delay, () {});
       setThemeMode(isDarkMode ? ThemeMode.light : ThemeMode.dark);
     } else {
       bool isDarkMode = themeMode == ThemeMode.dark;
+
+      if (delay != null) await Future.delayed(delay, () {});
       setThemeMode(isDarkMode ? ThemeMode.light : ThemeMode.dark);
     }
   }

--- a/lib/views/stories/local_widgets/layouts/pages_layout.dart
+++ b/lib/views/stories/local_widgets/layouts/pages_layout.dart
@@ -28,7 +28,7 @@ class _PagesLayoutState extends State<_PagesLayout> {
   }
 
   void _setPageOffset() {
-    pageOffset.value = widget.builder.pageController?.page ?? 0.0;
+    pageOffset.value = widget.builder.pageController?.offset ?? 0.0;
   }
 
   @override
@@ -48,30 +48,26 @@ class _PagesLayoutState extends State<_PagesLayout> {
       itemBuilder: (context, index) {
         return Stack(
           children: [
-            SpDefaultScrollController(builder: (context, scrollController) {
-              return Scrollbar(
-                controller: scrollController,
-                interactive: true,
-                child: SingleChildScrollView(
-                  clipBehavior: Clip.none,
-                  controller: scrollController,
-                  padding: EdgeInsets.only(
-                    bottom: keyboardOpened ? widget.builder.viewInsets.bottom + 16.0 : 16.0,
+            SingleChildScrollView(
+              clipBehavior: Clip.none,
+              padding: EdgeInsets.only(
+                bottom: keyboardOpened ? widget.builder.viewInsets.bottom + 16.0 : 16.0,
+              ),
+              child: Column(
+                children: [
+                  if (widget.builder.headerBuilder != null) buildHeader(index, screenWidth),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(minHeight: 200),
+                    child: widget.builder.buildPage(
+                      widget.builder.pages[index],
+                      context,
+                      smallPage: false,
+                    ),
                   ),
-                  child: Column(
-                    children: [
-                      if (widget.builder.headerBuilder != null) buildHeader(index, screenWidth),
-                      widget.builder.buildPage(
-                        widget.builder.pages[index],
-                        context,
-                        smallPage: false,
-                      ),
-                      widget.builder._buildAddButton(),
-                    ],
-                  ),
-                ),
-              );
-            }),
+                  widget.builder._buildAddButton(),
+                ],
+              ),
+            ),
             buildPageNumber(index, context),
           ],
         );
@@ -85,20 +81,33 @@ class _PagesLayoutState extends State<_PagesLayout> {
       child: widget.builder.headerBuilder!(widget.builder.pages[pageIndex]),
       builder: (context, offset, child) {
         SpPageViewDatas datas = SpPageViewDatas.fromOffset(
-          pageOffset: offset,
           itemIndex: pageIndex,
           controller: widget.builder.pageController!,
           width: screenWidth,
         );
 
-        return Transform(
-          transform: Matrix4.identity()
-            ..spTranslate(datas.translateX1)
-            ..spTranslate(datas.translateX2 ?? 0),
-          child: Opacity(
-            opacity: datas.opacity,
-            child: child,
-          ),
+        return Column(
+          children: [
+            Transform(
+              transform: Matrix4.identity()
+                ..spTranslate(datas.translateX1)
+                ..spTranslate(datas.translateX2 ?? 0),
+              child: Opacity(
+                opacity: datas.opacity,
+                child: child!,
+              ),
+            ),
+            Transform(
+              transform: Matrix4.identity()..spTranslate(offset - pageIndex * screenWidth),
+              child: Opacity(
+                opacity: datas.opacity,
+                child: const Padding(
+                  padding: EdgeInsetsGeometry.only(top: 8.0),
+                  child: Divider(height: 1, indent: 0.0, endIndent: 0.0),
+                ),
+              ),
+            ),
+          ],
         );
       },
     );

--- a/lib/views/stories/local_widgets/story_page.dart
+++ b/lib/views/stories/local_widgets/story_page.dart
@@ -99,11 +99,6 @@ class _StoryPage extends StatelessWidget {
             ),
           ),
         ],
-        if (!smallPage) ...[
-          const SizedBox(height: 4),
-          const Divider(height: 1, indent: 0.0, endIndent: 0.0),
-          const SizedBox(height: 8),
-        ],
         Padding(
           padding: smallPage ? EdgeInsets.zero : const EdgeInsets.symmetric(horizontal: 4.0),
           child: _QuillEditor(

--- a/lib/views/stories/local_widgets/story_pages_builder.dart
+++ b/lib/views/stories/local_widgets/story_pages_builder.dart
@@ -21,7 +21,6 @@ import 'package:storypad/providers/device_preferences_provider.dart';
 import 'package:storypad/widgets/custom_embed/sp_date_block_embed.dart';
 import 'package:storypad/widgets/custom_embed/sp_image_block_embed.dart';
 import 'package:storypad/widgets/sp_animated_icon.dart';
-import 'package:storypad/widgets/sp_default_scroll_controller.dart';
 import 'package:storypad/widgets/sp_floating_pop_up_button.dart';
 import 'package:storypad/widgets/sp_focus_node_builder2.dart';
 import 'package:storypad/widgets/sp_icons.dart';

--- a/lib/widgets/bottom_sheets/sp_story_theme_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_story_theme_bottom_sheet.dart
@@ -1,8 +1,6 @@
 // TODO: fix color.value deprecation
 // ignore_for_file: deprecated_member_use
 
-import 'dart:io';
-
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -146,17 +144,6 @@ class _StoryThemeSheetState extends State<StoryThemeSheet> {
               widget.onThemeChanged(preferences);
             },
           ),
-          ListTile(
-            leading: Icon(SpIcons.book),
-            title: Text(tr("button.manage_pages")),
-            subtitle: Text(plural('plural.page', widget.draftContent?.richPages?.length ?? 0)),
-            trailing: const Icon(SpIcons.keyboardRight),
-            onTap: () async {
-              await Navigator.maybePop(context);
-              FocusManager.instance.primaryFocus?.unfocus();
-              widget.viewModel.pagesManager.toggleManagingPage();
-            },
-          ),
           const Divider(height: 1),
           const SizedBox(height: 12.0),
           SpLayoutTypeSection(
@@ -219,10 +206,15 @@ class _StoryThemeSheetState extends State<StoryThemeSheet> {
       buildMoreOptionsButton(context),
       IconButton(
         onPressed: () {
-          if (Platform.isAndroid) context.read<DevicePreferencesProvider>().toggleThemeMode(context);
-
-          // TODO: fix material modal to dynamic base on theme mode instead of pop
-          Navigator.maybePop(context);
+          if (kIsCupertino) {
+            context.read<DevicePreferencesProvider>().toggleThemeMode(context);
+          } else {
+            context
+                .read<DevicePreferencesProvider>()
+                .toggleThemeMode(context, delay: const Duration(milliseconds: 300));
+            // TODO: fix material modal to dynamic base on theme mode instead of pop
+            Navigator.maybePop(context);
+          }
         },
         icon: SpThemeModeIcon(parentContext: context),
       ),

--- a/lib/widgets/sp_page_view_datas.dart
+++ b/lib/widgets/sp_page_view_datas.dart
@@ -13,7 +13,6 @@ class SpPageViewDatas {
   );
 
   factory SpPageViewDatas.fromOffset({
-    required double pageOffset,
     required int itemIndex,
     required PageController controller,
     required double width,

--- a/lib/widgets/sp_story_labels.dart
+++ b/lib/widgets/sp_story_labels.dart
@@ -99,6 +99,7 @@ class SpStoryLabels extends StatelessWidget {
         buildPin(
           leadingIconData: SpIcons.managingPage,
           context: context,
+          tooltip: tr('button.manage_pages'),
           title: plural("plural.page", pageCount),
           onTap: onToggleManagingPage,
         ),
@@ -184,10 +185,11 @@ class SpStoryLabels extends StatelessWidget {
     );
   }
 
-  Material buildPin({
+  Widget buildPin({
     required BuildContext context,
     required String title,
     required void Function()? onTap,
+    String? tooltip,
     IconData? leadingIconData,
   }) {
     Widget text;
@@ -210,7 +212,7 @@ class SpStoryLabels extends StatelessWidget {
       );
     }
 
-    return Material(
+    final child = Material(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4.0)),
       color: (AppTheme.isDarkMode(context) ? Colors.white : Colors.black).withValues(alpha: 0.06),
       child: InkWell(
@@ -224,6 +226,11 @@ class SpStoryLabels extends StatelessWidget {
           child: text,
         ),
       ),
+    );
+
+    return Tooltip(
+      message: tooltip ?? title,
+      child: child,
     );
   }
 }


### PR DESCRIPTION
In this PR, I've:
- [x] Moved divider to above title instead (for consistency across page & layouts)
- [x] Added transition animation to divider.
- [x] Removed manage pages from theme sheet (we can click on `4 pages` as in video instead)
- [x] Add minimum page height (so add new page button not appear too much on top) 

https://github.com/user-attachments/assets/51e1ff2c-2c4b-43e5-a1c6-6bf6cf2cab43

