### PR TITLE
Remove redeem code for IOS

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -10,6 +10,7 @@ const String kRevenueCatIosApiKey = String.fromEnvironment('REVENUE_CAT_IOS_API_
 const String kEmailHasherSecreyKey = String.fromEnvironment('EMAIL_HASHER_SECRET_KEY');
 
 const bool kIsCupertino = String.fromEnvironment('CUPERTINO') == 'yes';
+final bool kRedeemCodeEnabled = Platform.isAndroid;
 
 const Color kSplashColor = Colors.transparent;
 const Color kDefaultColorSeed = Colors.black;

--- a/lib/views/add_ons/add_ons_content.dart
+++ b/lib/views/add_ons/add_ons_content.dart
@@ -38,6 +38,7 @@ class _AddOnsContent extends StatelessWidget {
       itemCount: viewModel.addOns!.length + 1,
       itemBuilder: (context, index) {
         if (index == viewModel.addOns!.length) {
+          if (!kRedeemCodeEnabled || !kIAPEnabled) return const SizedBox.shrink();
           return buildRewardsCard();
         }
 

--- a/lib/views/home/local_widgets/end_drawer/add_ons_tile.dart
+++ b/lib/views/home/local_widgets/end_drawer/add_ons_tile.dart
@@ -11,14 +11,16 @@ class _AddOnsTile extends StatelessWidget {
         return ListTile(
           contentPadding: const EdgeInsets.only(left: 16.0, right: 8.0),
           leading: const Icon(SpIcons.addOns),
-          trailing: IconButton(
-            tooltip: tr('list_tile.unlock_your_rewards.unapplied_title'),
-            icon: const Icon(SpIcons.gift),
-            onPressed: () async {
-              await SpRewardSheet().show(context: context);
-              if (context.mounted) const AddOnsRoute().push(context);
-            },
-          ),
+          trailing: kRedeemCodeEnabled && kIAPEnabled
+              ? IconButton(
+                  tooltip: tr('list_tile.unlock_your_rewards.unapplied_title'),
+                  icon: const Icon(SpIcons.gift),
+                  onPressed: () async {
+                    await SpRewardSheet().show(context: context);
+                    if (context.mounted) const AddOnsRoute().push(context);
+                  },
+                )
+              : null,
           title: RichText(
             textScaler: MediaQuery.textScalerOf(context),
             text: TextSpan(

--- a/lib/views/library/library_content.dart
+++ b/lib/views/library/library_content.dart
@@ -1,9 +1,13 @@
 part of 'library_view.dart';
 
 class _LibraryContent extends StatelessWidget {
-  const _LibraryContent(this.viewModel);
+  const _LibraryContent(
+    this.viewModel, {
+    required this.constraints,
+  });
 
   final LibraryViewModel viewModel;
+  final BoxConstraints constraints;
 
   @override
   Widget build(BuildContext context) {
@@ -29,8 +33,12 @@ class _LibraryContent extends StatelessWidget {
       return _EmptyBody(context: context);
     }
 
-    return LayoutBuilder(builder: (context, constraints) {
-      return MasonryGridView.builder(
+    return Scrollbar(
+      thumbVisibility: true,
+      interactive: true,
+      child: MasonryGridView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        addAutomaticKeepAlives: false,
         padding: EdgeInsets.only(
           top: 16.0,
           bottom: MediaQuery.of(context).padding.bottom + 16.0,
@@ -45,8 +53,8 @@ class _LibraryContent extends StatelessWidget {
           final asset = viewModel.assets!.items[index];
           return buildItem(asset, provider, context);
         },
-      );
-    });
+      ),
+    );
   }
 
   Widget buildItem(AssetDbModel asset, BackupProvider provider, BuildContext context) {

--- a/lib/views/library/library_view.dart
+++ b/lib/views/library/library_view.dart
@@ -42,7 +42,9 @@ class LibraryView extends StatelessWidget {
     return ViewModelProvider<LibraryViewModel>(
       create: (context) => LibraryViewModel(params: params),
       builder: (context, viewModel, child) {
-        return _LibraryContent(viewModel);
+        return LayoutBuilder(builder: (context, constraints) {
+          return _LibraryContent(viewModel, constraints: constraints);
+        });
       },
     );
   }

--- a/lib/views/relax_sounds/local_widgets/mixes_tab.dart
+++ b/lib/views/relax_sounds/local_widgets/mixes_tab.dart
@@ -51,6 +51,7 @@ class _MixesTab extends StatelessWidget {
       onReorder: (int oldIndex, int newIndex) => viewModel.reorder(oldIndex, newIndex),
       itemBuilder: (context, index) {
         if (index == viewModel.mixes!.length) {
+          if (!kRedeemCodeEnabled || !kIAPEnabled) return const SizedBox(key: ValueKey('share_to_social'));
           return Padding(
             key: const ValueKey('share_to_social'),
             padding: const EdgeInsets.all(6.0),

--- a/lib/widgets/bottom_sheets/sp_image_picker_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_image_picker_bottom_sheet.dart
@@ -147,28 +147,35 @@ class SpImagePickerBottomSheet extends BaseBottomSheet {
       );
     }
 
-    return MasonryGridView.builder(
+    return Scrollbar(
+      thumbVisibility: true,
+      interactive: true,
       controller: PrimaryScrollController.maybeOf(context),
-      padding: const EdgeInsets.symmetric(horizontal: 16.0)
-          .copyWith(top: 16.0, bottom: MediaQuery.of(context).padding.bottom + 16.0),
-      itemCount: assets.length,
-      mainAxisSpacing: 8.0,
-      crossAxisSpacing: 8.0,
-      gridDelegate: SliverSimpleGridDelegateWithFixedCrossAxisCount(crossAxisCount: constraints.maxWidth ~/ 120),
-      itemBuilder: (BuildContext context, int index) {
-        final asset = assets[index];
-        return GestureDetector(
-          onTap: () => Navigator.pop(context, [asset]),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(8.0),
-            child: SpImage(
-              link: asset.link,
-              width: double.infinity,
-              height: 120,
+      child: MasonryGridView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        addAutomaticKeepAlives: false,
+        controller: PrimaryScrollController.maybeOf(context),
+        padding: const EdgeInsets.symmetric(horizontal: 16.0)
+            .copyWith(top: 16.0, bottom: MediaQuery.of(context).padding.bottom + 16.0),
+        itemCount: assets.length,
+        mainAxisSpacing: 8.0,
+        crossAxisSpacing: 8.0,
+        gridDelegate: SliverSimpleGridDelegateWithFixedCrossAxisCount(crossAxisCount: constraints.maxWidth ~/ 120),
+        itemBuilder: (BuildContext context, int index) {
+          final asset = assets[index];
+          return GestureDetector(
+            onTap: () => Navigator.pop(context, [asset]),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8.0),
+              child: SpImage(
+                link: asset.link,
+                width: double.infinity,
+                height: 120,
+              ),
             ),
-          ),
-        );
-      },
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/widgets/bottom_sheets/sp_share_story_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_share_story_bottom_sheet.dart
@@ -169,7 +169,7 @@ class _ShareStoryBottomSheetState extends State<_ShareStoryBottomSheet> {
                 onSubmitted: (value) => share(),
               ),
             ),
-            if (kIAPEnabled) buildShareToSocialCard(context),
+            if (kIAPEnabled && kRedeemCodeEnabled) buildShareToSocialCard(context),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.17.2+463
+version: 2.17.2+464
 publish_to: none
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
This is a temporary solution; a long-term solution would be to adopt the Apple redeem code. Its limitation is that it does not have an expiration date (our feature required it), which required us to create subscription products just for that.