### PR TITLE
Adjust add-on prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Backup & sync** – private Google Drive sync & offline local export
 - **Themes & customization** – 20+ color themes, dark/light mode, fonts & layouts
 - **Export & share** – text, markdown, or full backups
-- **Add-ons** – enhance your writing experience (all $0.99 one-time purchase):
+- **Add-ons** – enhance your writing experience (all $1.99 one-time purchase):
   - **[Templates](docs/features/templates/overview.md)** – Create your own daily writing templates
   - **[Relaxing Sounds](docs/features/relaxing-sounds/overview.md)** – Set the mood before you write or read
   - **[Period Calendar](docs/features/period-calendar/overview.md)** – Track your period and create related story entries

--- a/docs/features/period-calendar/implementation.md
+++ b/docs/features/period-calendar/implementation.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-A simple calendar feature for tracking period dates and creating related story entries. Available as a paid add-on ($0.99).
+A simple calendar feature for tracking period dates and creating related story entries. Available as a paid add-on ($1.99).
 
 **Key Principles:**
 
@@ -97,7 +97,7 @@ AddOnObject(
   type: AppProduct.period_calendar,
   title: 'Period Calendar',
   subtitle: 'Understand your cycle and feelings',
-  displayPrice: '\$0.99',
+  displayPrice: '\$1.99',
   iconData: SpIcons.calendar,
   weekdayColor: 5,
 )

--- a/docs/features/period-calendar/overview.md
+++ b/docs/features/period-calendar/overview.md
@@ -1,6 +1,6 @@
 # Period Calendar Add-on
 
-**Price:** $0.99 (one-time purchase, lifetime access)
+**Price:** $1.99 (one-time purchase, lifetime access)
 
 ## Description
 

--- a/docs/features/relaxing-sounds/overview.md
+++ b/docs/features/relaxing-sounds/overview.md
@@ -1,6 +1,6 @@
 # Relaxing Sounds Add-on
 
-**Price:** $0.99 (one-time purchase)
+**Price:** $1.99 (one-time purchase)
 
 ## Description
 

--- a/docs/features/templates/overview.md
+++ b/docs/features/templates/overview.md
@@ -1,6 +1,6 @@
 # Templates Add-on
 
-**Price:** $0.99 (one-time purchase)
+**Price:** $1.99 (one-time purchase)
 
 ## Description
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -27,7 +27,7 @@ Product-focused documentation for marketing, planning, and strategic decisions.
 ### Monetization
 
 - Free core app (no ads, no subscriptions)
-- Optional $0.99 add-ons (Relaxing Sounds, Templates)
+- Optional $1.99 add-ons (Relaxing Sounds, Templates)
 - Future: Premium tier when add-on library grows
 
 ### Community

--- a/docs/product/overview.md
+++ b/docs/product/overview.md
@@ -21,7 +21,7 @@ Keep simplicity for a diary app & journal app while having more features & custo
 ## Monetization
 
 - **Free Core App:** No ads, no data selling, no subscriptions
-- **Optional Add-ons:** One-time purchases ($0.99 each)
+- **Optional Add-ons:** One-time purchases ($1.99 each)
   - Relaxing Sounds
   - Templates
 - **Future:** Premium tier planned when more add-ons are available

--- a/ios/StoreKit/StoryPad - Timeline Diary.storekit
+++ b/ios/StoreKit/StoryPad - Timeline Diary.storekit
@@ -15,7 +15,7 @@
   ],
   "products" : [
     {
-      "displayPrice" : "0.99",
+      "displayPrice" : "1.99",
       "familyShareable" : true,
       "internalID" : "6754039959",
       "localizations" : [
@@ -30,7 +30,7 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "0.99",
+      "displayPrice" : "1.99",
       "familyShareable" : true,
       "internalID" : "6748109452",
       "localizations" : [
@@ -45,7 +45,7 @@
       "type" : "NonConsumable"
     },
     {
-      "displayPrice" : "0.99",
+      "displayPrice" : "1.99",
       "familyShareable" : true,
       "internalID" : "6748109594",
       "localizations" : [


### PR DESCRIPTION
> We’re adjusting our price from $1.00 to $1.99 (tax included).

### Why the change?
- The old `$1.00` price didn’t include `taxes`, and app stores also take a `15%` (android), `30%` (ios) service fee, leaving us with only about `$0.5–$0.70`.
- Depending on your country, taxes made the final amount around `$1.49` even though we only set up 1$. This could be confusing or surprising for user at checkout.

<img width="300" alt="share_8660924943221797942" src="https://github.com/user-attachments/assets/1971a389-0b94-4b30-bdf6-0dfc01d926b8" />

### What’s better now?
- The new $1.99 price already includes all taxes and app store fees, so what you see is what you pay.
- This gives us a bit more breathing room (about $1-$1.50 after fees) to keep improving the app, feature, and occasionally run discounts - for example, $1.99 → $0.49 promotions that actually make a difference.

We appreciate your understanding; this small change helps us stay independent, sustainable, and continue building a better experience for you ❤️