### PR TITLE
Fix broken images in docs

### DIFF
--- a/docs/features/period-calendar/overview.md
+++ b/docs/features/period-calendar/overview.md
@@ -17,7 +17,7 @@ Track your period cycle with ease, right inside your StoryPad journal. The Perio
 
 |                                                                                               |                                                                                               |                                                                                               |     |
 | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------: | --- |
-| ![Screenshot 1](../../firestore_storages/add_ons_demos/period_calendar/period_calendar_1.jpg) | ![Screenshot 2](../../firestore_storages/add_ons_demos/period_calendar/period_calendar_2.jpg) | ![Screenshot 3](../../firestore_storages/add_ons_demos/period_calendar/period_calendar_3.jpg) |
+| ![Screenshot 1](../../../firestore_storages/add_ons_demos/period_calendar/period_calendar_1.jpg) | ![Screenshot 2](../../../firestore_storages/add_ons_demos/period_calendar/period_calendar_2.jpg) | ![Screenshot 3](../../../firestore_storages/add_ons_demos/period_calendar/period_calendar_3.jpg) |
 
 ## Features
 

--- a/docs/features/relaxing-sounds/overview.md
+++ b/docs/features/relaxing-sounds/overview.md
@@ -10,7 +10,7 @@ Set the mood before you write or read. The Relaxing Sounds add-on provides ambie
 
 |                                      Screenshot 1                                      |                                      Screenshot 2                                      |                                      Screenshot 3                                      |                                      Screenshot 4                                      |
 | :------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------: |
-| ![Screenshot 1](../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_1.jpg) | ![Screenshot 2](../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_2.jpg) | ![Screenshot 3](../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_3.jpg) | ![Screenshot 4](../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_4.jpg) |
+| ![Screenshot 1](../../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_1.jpg) | ![Screenshot 2](../../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_2.jpg) | ![Screenshot 3](../../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_3.jpg) | ![Screenshot 4](../../../firestore_storages/add_ons_demos/relax_sounds/relax_sound_4.jpg) |
 
 ## Features
 

--- a/docs/features/templates/overview.md
+++ b/docs/features/templates/overview.md
@@ -10,7 +10,7 @@ Create your own daily writing templates. The Templates add-on allows you to desi
 
 |                                                                                  |                                                                                  |                                                                                  |                                                                                  |
 | :------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: |
-| ![Screenshot 1](../../firestore_storages/add_ons_demos/templates/template_1.jpg) | ![Screenshot 2](../../firestore_storages/add_ons_demos/templates/template_2.jpg) | ![Screenshot 3](../../firestore_storages/add_ons_demos/templates/template_3.jpg) | ![Screenshot 4](../../firestore_storages/add_ons_demos/templates/template_4.jpg) |
+| ![Screenshot 1](../../../firestore_storages/add_ons_demos/templates/template_1.jpg) | ![Screenshot 2](../../../firestore_storages/add_ons_demos/templates/template_2.jpg) | ![Screenshot 3](../../../firestore_storages/add_ons_demos/templates/template_3.jpg) | ![Screenshot 4](../../../firestore_storages/add_ons_demos/templates/template_4.jpg) |
 
 ## Features
 


### PR DESCRIPTION
Have you moved the "firestore_storages" to upper level (outside docs) recently?

The children in [docs / features](https://github.com/theachoem/storypad/tree/develop/docs/features) had broken images:
- [Templates](https://github.com/theachoem/storypad/blob/develop/docs/features/templates/overview.md) 
- [Relaxing Sounds](https://github.com/theachoem/storypad/blob/develop/docs/features/relaxing-sounds/overview.md) 
- [Period Calendar](https://github.com/theachoem/storypad/blob/develop/docs/features/period-calendar/overview.md)

This is a simply fix changing for one more level `../` 