### PR TITLE
Improve theme picker sheet

### DIFF
--- a/lib/providers/device_preferences_provider.dart
+++ b/lib/providers/device_preferences_provider.dart
@@ -122,7 +122,7 @@ class DevicePreferencesProvider extends ChangeNotifier {
     _listeners['voice_playback_speed']?.forEach((listener) => listener());
   }
 
-  void toggleThemeMode(
+  Future<void> toggleThemeMode(
     BuildContext context, {
     Duration? delay,
   }) async {

--- a/lib/views/rewards/local_widgets/rewards_header.dart
+++ b/lib/views/rewards/local_widgets/rewards_header.dart
@@ -36,7 +36,10 @@ class _RewardsHeader extends StatelessWidget {
                 return SizedBox(
                   width: 88,
                   height: 88,
-                  child: Image.file(file),
+                  child: Image.file(
+                    file,
+                    cacheWidth: (88 * MediaQuery.of(context).devicePixelRatio).round(),
+                  ),
                 );
               },
             ),

--- a/lib/views/templates/local_widgets/gallery_template_card.dart
+++ b/lib/views/templates/local_widgets/gallery_template_card.dart
@@ -38,6 +38,7 @@ class _GalleryTemplateCard extends StatelessWidget {
                   width: 36,
                   height: 36,
                   semanticLabel: template.name,
+                  cacheWidth: (36 * MediaQuery.of(context).devicePixelRatio).round(),
                 );
               },
             ),

--- a/lib/widgets/bottom_sheets/base_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/base_bottom_sheet.dart
@@ -22,6 +22,41 @@ abstract class BaseBottomSheet {
 
   Color? getBackgroundColor(BuildContext context) => null;
 
+  Future<T?> showReplacement<T>({
+    required BuildContext context,
+    bool useRootNavigator = false,
+  }) {
+    if (kIsCupertino) throw UnimplementedError('Replacement bottom sheet is not implemented for Cupertino.');
+
+    return replaceModalBottomSheet<T>(
+      useRootNavigator: useRootNavigator,
+      context: context,
+      showDragHandle: showMaterialDragHandle,
+      isScrollControlled: true,
+      barrierColor: barrierColor,
+      backgroundColor: getBackgroundColor(context),
+      sheetAnimationStyle: .noAnimation,
+      builder: (context) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            scaffoldBackgroundColor: Colors.transparent,
+            appBarTheme: const AppBarTheme(backgroundColor: Colors.transparent, surfaceTintColor: Colors.transparent),
+          ),
+          // No need left or right default padding for sheet.
+          child: MediaQuery.removePadding(
+            context: context,
+            removeLeft: true,
+            removeRight: true,
+            child: build(
+              context,
+              MediaQuery.of(context).padding.bottom + MediaQuery.of(context).viewInsets.bottom,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   Future<T?> show<T>({
     required BuildContext context,
     bool useRootNavigator = false,
@@ -171,4 +206,61 @@ abstract class BaseBottomSheet {
   }
 
   Widget build(BuildContext context, double bottomPadding);
+}
+
+/// Complete copy of [showModalBottomSheet] but replaces the current route
+/// instead of pushing a new one.
+Future<T?> replaceModalBottomSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  Color? backgroundColor,
+  String? barrierLabel,
+  double? elevation,
+  ShapeBorder? shape,
+  Clip? clipBehavior,
+  BoxConstraints? constraints,
+  Color? barrierColor,
+  bool isScrollControlled = false,
+  double scrollControlDisabledMaxHeightRatio = 9.0 / 16.0,
+  bool useRootNavigator = false,
+  bool isDismissible = true,
+  bool enableDrag = true,
+  bool? showDragHandle,
+  bool useSafeArea = false,
+  RouteSettings? routeSettings,
+  AnimationController? transitionAnimationController,
+  Offset? anchorPoint,
+  AnimationStyle? sheetAnimationStyle,
+  bool? requestFocus,
+}) {
+  assert(debugCheckHasMediaQuery(context));
+  assert(debugCheckHasMaterialLocalizations(context));
+
+  final NavigatorState navigator = Navigator.of(context, rootNavigator: useRootNavigator);
+  final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+  return navigator.pushReplacement(
+    ModalBottomSheetRoute<T>(
+      builder: builder,
+      capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
+      isScrollControlled: isScrollControlled,
+      scrollControlDisabledMaxHeightRatio: scrollControlDisabledMaxHeightRatio,
+      barrierLabel: barrierLabel ?? localizations.scrimLabel,
+      barrierOnTapHint: localizations.scrimOnTapHint(localizations.bottomSheetLabel),
+      backgroundColor: backgroundColor,
+      elevation: elevation,
+      shape: shape,
+      clipBehavior: clipBehavior,
+      constraints: constraints,
+      isDismissible: isDismissible,
+      modalBarrierColor: barrierColor ?? Theme.of(context).bottomSheetTheme.modalBarrierColor,
+      enableDrag: enableDrag,
+      showDragHandle: showDragHandle,
+      settings: routeSettings,
+      transitionAnimationController: transitionAnimationController,
+      anchorPoint: anchorPoint,
+      useSafeArea: useSafeArea,
+      sheetAnimationStyle: sheetAnimationStyle,
+      requestFocus: requestFocus,
+    ),
+  );
 }

--- a/lib/widgets/bottom_sheets/sp_android_redemption_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_android_redemption_sheet.dart
@@ -153,6 +153,7 @@ class SpAndroidRedemptionSheet extends BaseBottomSheet {
               width: imageWidth,
               height: imageHeight,
               fit: BoxFit.cover,
+              cacheWidth: (imageWidth * MediaQuery.of(context).devicePixelRatio).round(),
             );
           },
         ),

--- a/lib/widgets/bottom_sheets/sp_story_theme_bottom_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_story_theme_bottom_sheet.dart
@@ -8,6 +8,7 @@ import 'package:storypad/core/mixins/debounched_callback.dart';
 import 'package:storypad/core/types/editing_flow_type.dart';
 import 'package:storypad/providers/device_preferences_provider.dart';
 import 'package:storypad/providers/in_app_purchase_provider.dart';
+import 'package:storypad/views/home/home_view.dart';
 import 'package:storypad/views/rewards/rewards_view.dart';
 import 'package:storypad/views/stories/local_widgets/base_story_view_model.dart';
 import 'package:storypad/views/settings/local_widgets/font_family_tile.dart';
@@ -125,6 +126,7 @@ class _StoryThemeSheetState extends State<_StoryThemeSheet> with DebounchedCallb
           const Divider(height: 1),
           const SizedBox(height: 8.0),
           SpBackgroundPicker(
+            backgroundColor: ColorScheme.of(context).surfaceContainerLow,
             colorSeedValue: preferences.colorSeedValue,
             colorTone: preferences.colorTone,
             backgroundImagePath: preferences.backgroundImagePath,
@@ -322,7 +324,20 @@ class _StoryThemeSheetState extends State<_StoryThemeSheet> with DebounchedCallb
         ),
       SpFadeIn.bound(
         child: IconButton(
-          onPressed: () => context.read<DevicePreferencesProvider>().toggleThemeMode(context),
+          onPressed: () async {
+            await context.read<DevicePreferencesProvider>().toggleThemeMode(context);
+            if (!context.mounted) return;
+
+            // for android, sheet replacement to apply theme mode immediately.
+            // otherwise, just skip.
+            if (kIsCupertino) return;
+
+            SpStoryThemeBottomSheet(
+              onThemeChanged: widget.onThemeChanged,
+              preferences: preferences,
+              storyViewModel: storyViewModel,
+            ).showReplacement(context: HomeView.homeContext!);
+          },
           icon: SpThemeModeIcon(parentContext: context),
         ),
       ),

--- a/lib/widgets/sp_background_picker.dart
+++ b/lib/widgets/sp_background_picker.dart
@@ -36,12 +36,14 @@ class SpBackgroundPicker extends StatefulWidget {
     required this.colorTone,
     required this.backgroundImagePath,
     required this.onThemeChanged,
+    required this.backgroundColor,
   });
 
   final int? colorSeedValue;
   final int? colorTone;
   final String? backgroundImagePath;
   final OnBackgroundThemeChanged onThemeChanged;
+  final Color backgroundColor;
 
   @override
   State<SpBackgroundPicker> createState() => _SpBackgroundPickerState();
@@ -166,9 +168,9 @@ class _SpBackgroundPickerState extends State<SpBackgroundPicker> with Debounched
                     begin: .centerLeft,
                     end: .centerRight,
                     colors: [
-                      Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.0),
-                      Theme.of(context).scaffoldBackgroundColor,
-                      Theme.of(context).scaffoldBackgroundColor,
+                      widget.backgroundColor.withValues(alpha: 0.0),
+                      widget.backgroundColor,
+                      widget.backgroundColor,
                     ],
                   ),
                 ),
@@ -278,7 +280,7 @@ class _ImageBackgroundCarouselState extends State<_ImageBackgroundCarousel> {
 
   // First 3 backgrounds has no restriction.
   bool isLocked(int index) {
-    return index > 0 && !context.read<InAppPurchaseProvider>().backgrounds;
+    return index > 1 && !context.read<InAppPurchaseProvider>().backgrounds;
   }
 
   @override
@@ -286,6 +288,10 @@ class _ImageBackgroundCarouselState extends State<_ImageBackgroundCarousel> {
     controller.dispose();
     super.dispose();
   }
+
+  double get itemExtent => _backgroundCardHeight * _backgroundCardAspectRatio;
+  EdgeInsets get itemPadding => const EdgeInsets.symmetric(horizontal: 6.0);
+  double get itemWidth => itemExtent - itemPadding.horizontal * 2;
 
   @override
   Widget build(BuildContext context) {
@@ -299,8 +305,8 @@ class _ImageBackgroundCarouselState extends State<_ImageBackgroundCarousel> {
       ),
       child: CarouselView(
         controller: controller,
-        itemExtent: _backgroundCardHeight * _backgroundCardAspectRatio,
-        padding: const EdgeInsets.symmetric(horizontal: 6.0),
+        itemExtent: itemExtent,
+        padding: itemPadding,
         shape: RoundedRectangleBorder(
           side: BorderSide(color: Theme.of(context).dividerColor, width: 1.0),
           borderRadius: BorderRadius.circular(8.0),
@@ -327,6 +333,7 @@ class _ImageBackgroundCarouselState extends State<_ImageBackgroundCarousel> {
             background: widget.backgrounds[index],
             locked: isLocked(index),
             selected: isSelected(widget.backgrounds[index]),
+            itemWidth: itemWidth,
           );
         }),
       ),
@@ -339,11 +346,13 @@ class _ImageItem extends StatelessWidget {
     required this.background,
     required this.locked,
     required this.selected,
+    required this.itemWidth,
   });
 
   final StoryBackground background;
   final bool locked;
   final bool selected;
+  final double itemWidth;
 
   @override
   Widget build(BuildContext context) {
@@ -374,6 +383,7 @@ class _ImageItem extends StatelessWidget {
           filePath: background.path,
           builder: (context, file, failed) {
             if (failed || file == null) return const SizedBox.shrink();
+
             return Image.file(
               file,
               fit: .cover,
@@ -383,6 +393,11 @@ class _ImageItem extends StatelessWidget {
                 .center => .center,
                 .right => .centerRight,
               },
+
+              // Each background card is ~86.4px wide (or itemWidth), but BoxFit.cover crops the image based on alignment (left/center/right),
+              // so only a portion of the original image is visible. We multiply by 3 to ensure the displayed area is rendered sharply.
+              // Using cacheWidth improves performance by decoding only the necessary resolution.
+              cacheWidth: (itemWidth * 3 * MediaQuery.of(context).devicePixelRatio).round(),
             );
           },
         ),

--- a/lib/widgets/sp_image.dart
+++ b/lib/widgets/sp_image.dart
@@ -63,6 +63,7 @@ class SpImage extends StatelessWidget {
         base64.decode(link),
         width: width,
         height: height,
+        cacheWidth: width != null ? (width! * MediaQuery.of(context).devicePixelRatio).round() : null,
         fit: BoxFit.cover,
       );
     } else if (link.startsWith('http')) {
@@ -71,6 +72,7 @@ class SpImage extends StatelessWidget {
         width: width,
         height: height,
         fit: BoxFit.cover,
+        memCacheWidth: width != null ? (width! * MediaQuery.of(context).devicePixelRatio).round() : null,
         placeholder: (context, url) {
           return SizedBox(
             height: height ?? defaultSize,
@@ -85,6 +87,7 @@ class SpImage extends StatelessWidget {
         width: width,
         height: height,
         fit: BoxFit.cover,
+        cacheWidth: width != null ? (width! * MediaQuery.of(context).devicePixelRatio).round() : null,
       );
     } else {
       return buildImageError(

--- a/lib/widgets/sp_story_preference_theme.dart
+++ b/lib/widgets/sp_story_preference_theme.dart
@@ -64,11 +64,24 @@ class SpStoryPreferenceTheme extends StatelessWidget {
           builder: (context, file, failed) {
             if (file == null) return const SizedBox.shrink();
 
-            return switch (themeConstructor.selectedBackground!.align) {
-              .left => Image.file(file, fit: .cover, alignment: .centerLeft),
-              .center => Image.file(file, fit: .cover, alignment: .center),
-              .right => Image.file(file, fit: .cover, alignment: .centerRight),
-            };
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                return Image.file(
+                  file,
+                  fit: .cover,
+
+                  // The image is rendered to fill the widget, but BoxFit.cover crops it (only ~1/3 of the image width is visible).
+                  // To ensure the displayed part stays sharp, we multiply the widget width by 3 when setting cacheWidth.
+                  // Using cacheWidth improves performance by decoding a properly sized image.
+                  cacheWidth: (constraints.maxWidth * 3 * MediaQuery.of(context).devicePixelRatio).round(),
+                  alignment: switch (themeConstructor.selectedBackground!.align) {
+                    .left => .centerLeft,
+                    .center => .center,
+                    .right => .centerRight,
+                  },
+                );
+              },
+            );
           },
         ),
       );


### PR DESCRIPTION
In this PR:

1. Add cacheWidth to avoid image rendering glitch during scroll
2. Fix sheet theme don't change even after change theme mode
  - by replacing whole sheet with new theme sheet
  - This is probably a workaround for now and work really well. > Flutter Material Modal Sheet has a bad design for this.

https://github.com/user-attachments/assets/7832cc89-ac15-4744-98be-b02b9def5894