### PR TITLE
Fix google_font remove some font which cause white screen issue

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -166,7 +166,7 @@ class AppTheme extends StatelessWidget {
         ),
       ),
       textTheme: GoogleFonts.getTextTheme(
-        fontFamily,
+        GoogleFonts.asMap().keys.contains(fontFamily) ? fontFamily : kDefaultFontFamily,
         TextTheme(
           displayLarge: calculateTextStyle(baseTheme.textTheme.displayLarge!, FontWeight.w400),
           displayMedium: calculateTextStyle(baseTheme.textTheme.displayMedium!, FontWeight.w400),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.26.0+635
+version: 2.26.1+636
 publish_to: none
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
```
          Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Exception: No font family by name 'Roboto Condensed' was found.. Error thrown .
       at GoogleFonts.getTextTheme(google_fonts_all_parts.dart:4020)
       at AppTheme.getTheme(app_theme.dart:168)
       at SpStoryPreferenceThemeConstructor._construct(sp_story_preference_theme.dart:219)
       at .new SpStoryPreferenceThemeConstructor(sp_story_preference_theme.dart:126)
       at _SpStoryPreferenceThemeState.build(sp_story_preference_theme.dart:49)
       at StatefulElement.build(framework.dart:5931)
       at ComponentElement.performRebuild(framework.dart:5817)
       at StatefulElement.performRebuild(framework.dart:5982)
       at Element.rebuild(framework.dart:5529)
       at StatefulElement.update(framework.dart:6007)
       at Element.updateChild(framework.dart:4037)
       at SingleChildRenderObjectElement.update(framework.dart:7122)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at Element.rebuild(framework.dart:5529)
       at ProxyElement.update(framework.dart:6149)
       at _InheritedNotifierElement.update(inherited_notifier.dart:108)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at StatefulElement.performRebuild(framework.dart:5982)
       at Element.rebuild(framework.dart:5529)
       at StatefulElement.update(framework.dart:6007)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at Element.rebuild(framework.dart:5529)
       at StatelessElement.update(framework.dart:5895)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at StatefulElement.performRebuild(framework.dart:5982)
       at Element.rebuild(framework.dart:5529)
       at StatefulElement.update(framework.dart:6007)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at StatefulElement.performRebuild(framework.dart:5982)
       at Element.rebuild(framework.dart:5529)
       at StatefulElement.update(framework.dart:6007)
       at Element.updateChild(framework.dart:4037)
       at ComponentElement.performRebuild(framework.dart:5841)
       at Element.rebuild(framework.dart:5529)
       at BuildScope._tryRebuild(framework.dart:2750)
       at BuildScope._flushDirtyElements(framework.dart:2807)
       at BuildOwner.buildScope(framework.dart:3111)
       at _LayoutBuilderElement._rebuildWithConstraints(layout_builder.dart:270)
       at RenderAbstractLayoutBuilderMixin.layoutCallback(layout_builder.dart:333)
       at RenderObjectWithLayoutCallbackMixin.runLayoutCallback.<fn>(object.dart:4162)
       at RenderObject.invokeLayoutCallback.<fn>(object.dart:2887)
       at PipelineOwner._enableMutationsToDirtySubtrees(object.dart:1223)
       at RenderObject.invokeLayoutCallback(object.dart:2886)
       at RenderObjectWithLayoutCallbackMixin.runLayoutCallback(object.dart:4162)
       at _RenderLayoutBuilder.performLayout(layout_builder.dart:447)
       at RenderObject.layout(object.dart:2768)
       at MultiChildLayoutDelegate.layoutChild(custom_layout.dart:180)
       at _ScaffoldLayout.performLayout(scaffold.dart:1111)
       at MultiChildLayoutDelegate._callPerformLayout(custom_layout.dart:246)
       at RenderCustomMultiChildLayoutBox.performLayout(custom_layout.dart:417)
       at RenderObject.layout(object.dart:2768)
       at RenderProxyBoxMixin.performLayout(proxy_box.dart:118)
       at RenderObject.layout(object.dart:2768)
       at RenderProxyBoxMixin.performLayout(proxy_box.dart:118)
       at _RenderCustomClip.performLayout(proxy_box.dart:1549)
       at RenderObject.layout(object.dart:2768)
       at ChildLayoutHelper.layoutChild(layout_helper.dart:62)
       at RenderStack._computeSize(stack.dart:645)
       at RenderStack.performLayout(stack.dart:680)
       at RenderObject._layoutWithoutResize(object.dart:2616)
       at PipelineOwner.flushLayout(object.dart:1174)
       at PipelineOwner.flushLayout(object.dart:1187)
       at RendererBinding.drawFrame(binding.dart:629)
       at WidgetsBinding.drawFrame(binding.dart:1304)
       at RendererBinding._handlePersistentFrameCallback(binding.dart:495)
       at SchedulerBinding._invokeFrameCallback(binding.dart:1430)
       at SchedulerBinding.handleDrawFrame(binding.dart:1345)
       at SchedulerBinding._handleDrawFrame(binding.dart:1198)
        
```