### PR TITLE
Enhance Linux platform support and fix installation paths

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "be698c48a6750c8cb8e61c740ca9991bb947aba2"
+  revision: "cc0734ac716fbb8b90f3f9db8020958b1553afa7"
   channel: "stable"
 
 project_type: app
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-    - platform: macos
-      create_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
-      base_revision: be698c48a6750c8cb8e61c740ca9991bb947aba2
+      create_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+      base_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+    - platform: linux
+      create_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
+      base_revision: cc0734ac716fbb8b90f3f9db8020958b1553afa7
 
   # User provided section
 

--- a/lib/core/initializers/constants_initializer.dart
+++ b/lib/core/initializers/constants_initializer.dart
@@ -8,9 +8,16 @@ import 'package:storypad/core/services/app_logo_service.dart';
 
 class ConstantsInitializer {
   static Future<void> call() async {
-    kSupportDirectory = await getApplicationSupportDirectory();
+    kSupportDirectory = await _getDirectoryOrFallback(
+      getApplicationSupportDirectory,
+      Directory('${_homeDirectory.path}/.local/share/storypad'),
+    );
     kApplicationDirectory =
-        (Platform.isAndroid ? await getExternalStorageDirectory() : null) ?? await getApplicationDocumentsDirectory();
+        (Platform.isAndroid ? await getExternalStorageDirectory() : null) ??
+        await _getDirectoryOrFallback(
+          getApplicationDocumentsDirectory,
+          Directory('${_homeDirectory.path}/Documents/StoryPad'),
+        );
 
     kPackageInfo = await PackageInfo.fromPlatform();
     kDeviceInfo = await DeviceInfoObject.get();
@@ -18,5 +25,21 @@ class ConstantsInitializer {
     /// package:flutter/src/widgets/editable_text.dart [_processTextActions]
     kProcessTextActions = await DefaultProcessTextService().queryTextActions();
     kAppLogo = await AppLogoService().getCurrent();
+  }
+
+  static Directory get _homeDirectory {
+    return Directory(Platform.environment['HOME'] ?? Directory.current.path);
+  }
+
+  static Future<Directory> _getDirectoryOrFallback(
+    Future<Directory> Function() getter,
+    Directory fallback,
+  ) async {
+    try {
+      return await getter();
+    } catch (_) {
+      if (Platform.isLinux) return fallback;
+      rethrow;
+    }
   }
 }

--- a/lib/core/initializers/firebase_crashlytics_initializer.dart
+++ b/lib/core/initializers/firebase_crashlytics_initializer.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
+import 'package:storypad/core/utils/firebase_platform_support.dart';
 
 class FirebaseCrashlyticsInitializer {
   static void call() {
@@ -11,12 +12,18 @@ class FirebaseCrashlyticsInitializer {
   /// e.g. font downloads failing when the user has no internet access.
   static bool _isIgnorable(Object error) {
     final message = error.toString();
-    return message.contains('fonts.gstatic.com') && message.contains('SocketException');
+    return message.contains('fonts.gstatic.com') &&
+        message.contains('SocketException');
   }
 
   static void _listenToErrors() {
     FlutterError.onError = (FlutterErrorDetails details) {
       if (_isIgnorable(details.exception)) return;
+      if (!FirebasePlatformSupport.isSupported) {
+        FlutterError.presentError(details);
+        return;
+      }
+
       FirebaseCrashlytics.instance.recordFlutterFatalError(details);
     };
   }
@@ -24,6 +31,12 @@ class FirebaseCrashlyticsInitializer {
   static void _listenToNonFlutterErrors() {
     PlatformDispatcher.instance.onError = (error, stack) {
       if (_isIgnorable(error)) return true;
+      if (!FirebasePlatformSupport.isSupported) {
+        debugPrint(error.toString());
+        debugPrintStack(stackTrace: stack);
+        return true;
+      }
+
       FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
       return true;
     };

--- a/lib/core/services/analytics/analytics_service.dart
+++ b/lib/core/services/analytics/analytics_service.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:storypad/core/databases/models/asset_db_model.dart';
 import 'package:storypad/core/databases/models/collection_db_model.dart';
 import 'package:storypad/core/databases/models/story_db_model.dart';
@@ -21,14 +20,20 @@ class AnalyticsService extends BaseAnalyticsService {
   }) {
     String screenName = routeObject.analyticScreenName;
     String screenClass = routeObject.analyticScreenClass;
-    Map<String, Object>? parameters = sanitizeParameters(analyticsParameters ?? {});
+    Map<String, Object>? parameters = sanitizeParameters(
+      analyticsParameters ?? {},
+    );
 
     debug(
       'logViewRoute',
-      {'screen_name': screenName, 'screen_class': screenClass, ...parameters ?? {}},
+      {
+        'screen_name': screenName,
+        'screen_class': screenClass,
+        ...parameters ?? {},
+      },
     );
 
-    return FirebaseAnalytics.instance.logScreenView(
+    return firebaseAnalytics.logScreenView(
       screenClass: screenClass,
       screenName: screenName,
       parameters: parameters,
@@ -41,9 +46,12 @@ class AnalyticsService extends BaseAnalyticsService {
     String screenName = bottomSheet.analyticScreenName;
     String screenClass = bottomSheet.analyticScreenClass;
 
-    debug('logViewRoute', {'screen_name': screenName, 'screen_class': screenClass});
+    debug('logViewRoute', {
+      'screen_name': screenName,
+      'screen_class': screenClass,
+    });
 
-    return FirebaseAnalytics.instance.logScreenView(
+    return firebaseAnalytics.logScreenView(
       screenClass: screenClass,
       screenName: screenName,
       parameters: null,
@@ -56,7 +64,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'year': year.toString()});
     debug('logViewHome', parameters);
 
-    return FirebaseAnalytics.instance.logScreenView(
+    return firebaseAnalytics.logScreenView(
       screenClass: 'HomeView',
       screenName: 'Home',
       parameters: parameters,
@@ -69,7 +77,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'year': year.toString()});
     debug('logOpenHomeEndDrawer', parameters);
 
-    return FirebaseAnalytics.instance.logScreenView(
+    return firebaseAnalytics.logScreenView(
       screenClass: 'HomeEndDrawer',
       screenName: 'HomeEndDrawer',
       parameters: parameters,
@@ -79,7 +87,7 @@ class AnalyticsService extends BaseAnalyticsService {
   Future<void> logLicenseView() {
     debug('logLicenseView');
 
-    return FirebaseAnalytics.instance.logScreenView(
+    return firebaseAnalytics.logScreenView(
       screenClass: 'LicensePage',
       screenName: 'License',
       parameters: null,
@@ -93,7 +101,7 @@ class AnalyticsService extends BaseAnalyticsService {
       'searchTerm': searchTerm,
     });
 
-    return FirebaseAnalytics.instance.logSearch(
+    return firebaseAnalytics.logSearch(
       searchTerm: searchTerm,
     );
   }
@@ -101,7 +109,7 @@ class AnalyticsService extends BaseAnalyticsService {
   Future<void> logSyncBackup() {
     debug('logSyncBackup');
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('sync_backup'),
     );
   }
@@ -109,7 +117,7 @@ class AnalyticsService extends BaseAnalyticsService {
   Future<void> logImportOfflineBackup() {
     debug('logImportOfflineBackup');
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('import_offline_backup'),
     );
   }
@@ -117,28 +125,28 @@ class AnalyticsService extends BaseAnalyticsService {
   Future<void> logExportOfflineBackup() {
     debug('logExportOfflineBackup');
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('export_offline_backup'),
     );
   }
 
   Future<void> logRequestGoogleDriveScope() {
     debug('logRequestGoogleDriveScope');
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('request_google_drive_scope'),
     );
   }
 
   Future<void> logSignOut() {
     debug('logSignOut');
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('sign_out'),
     );
   }
 
   Future<void> logSignInWithGoogle() {
     debug('logSignInWithGoogle');
-    return FirebaseAnalytics.instance.logLogin(
+    return firebaseAnalytics.logLogin(
       loginMethod: 'google',
     );
   }
@@ -149,7 +157,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'url': url});
     debug('logOpenLinkInCustomTab', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('open_custom_tab'),
       parameters: parameters,
     );
@@ -161,7 +169,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'url': url});
     debug('logLaunchUrl', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('launch_url'),
       parameters: parameters,
     );
@@ -173,7 +181,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'target': target});
     debug('logSubmitRedditPost', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('submit_reddit_post'),
       parameters: parameters,
     );
@@ -185,7 +193,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({});
     debug('logDeleteCloudBackup', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('delete_cloud_backup'),
       parameters: parameters,
     );
@@ -197,7 +205,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({});
     debug('logDeleteAsset', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('delete_asset'),
       parameters: parameters,
     );
@@ -209,7 +217,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'version': backupFileInfo.version});
     debug('logForceRestoreBackup', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('force_restore_backup'),
       parameters: parameters,
     );
@@ -221,7 +229,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logHardDeleteStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('hard_delete_story'),
       parameters: parameters,
     );
@@ -233,7 +241,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logUndoHardDeleteStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('undo_hard_delete_story'),
       parameters: parameters,
     );
@@ -245,7 +253,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logImportIndividualStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('import_story_individually'),
       parameters: parameters,
     );
@@ -257,7 +265,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logMoveStoryToBin', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('move_story_to_bin'),
       parameters: parameters,
     );
@@ -269,7 +277,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logUndoMoveStoryToBin', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('undo_move_story_to_bin'),
       parameters: parameters,
     );
@@ -281,7 +289,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logUndoPutBack', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('undo_put_back'),
       parameters: parameters,
     );
@@ -293,7 +301,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logArchiveStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('archive_story'),
       parameters: parameters,
     );
@@ -305,7 +313,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logUndoArchiveStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('undo_archive_story'),
       parameters: parameters,
     );
@@ -317,7 +325,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logChangeStoryDate', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('change_story_date'),
       parameters: parameters,
     );
@@ -330,7 +338,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logSaveStoryAsTemplate', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('save_story_as_template'),
       parameters: parameters,
     );
@@ -342,7 +350,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logToggleStoryStarred', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('toggle_story_starred'),
       parameters: parameters,
     );
@@ -354,7 +362,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logReorderStoryPages', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('reorder_story_pages'),
       parameters: parameters,
     );
@@ -366,7 +374,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logAddStoryPage', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('add_story_page'),
       parameters: parameters,
     );
@@ -378,7 +386,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logDeleteStoryPage', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('delete_story_page'),
       parameters: parameters,
     );
@@ -390,7 +398,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logToggleShowDayCount', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('toggle_show_day_count'),
       parameters: parameters,
     );
@@ -402,7 +410,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logUpdateStoryPreferences', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('update_story_preferences'),
       parameters: parameters,
     );
@@ -414,7 +422,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logPutStoryBack', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('put_story_back'),
       parameters: parameters,
     );
@@ -426,7 +434,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logSetTagsToStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('set_tags_to_story'),
       parameters: parameters,
     );
@@ -438,7 +446,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logSetStoryFeeling', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('set_story_feeling'),
       parameters: parameters,
     );
@@ -450,7 +458,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logStorySaveDraft', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('story_save_draft'),
       parameters: parameters,
     );
@@ -462,7 +470,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logStoryContinueEdit', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('story_continue_edit'),
       parameters: parameters,
     );
@@ -474,7 +482,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logStoryViewPrevious', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('story_view_previous'),
       parameters: parameters,
     );
@@ -486,7 +494,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = storyAnalyticParameters(story);
     debug('logDiscardDraft', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('story_discard_draft'),
       parameters: parameters,
     );
@@ -498,7 +506,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = tagAnalyticParameters(tag);
     debug('logDeleteTag', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('delete_tag'),
       parameters: parameters,
     );
@@ -510,7 +518,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = tagAnalyticParameters(tag);
     debug('logEditTag', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('edit_tag'),
       parameters: parameters,
     );
@@ -522,7 +530,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = tagAnalyticParameters(tag);
     debug('logAddTag', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('add_tag'),
       parameters: parameters,
     );
@@ -532,21 +540,21 @@ class AnalyticsService extends BaseAnalyticsService {
     required CollectionDbModel<TagDbModel> tags,
   }) {
     debug('logReorderTags');
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('reorder_tags'),
     );
   }
 
   Future<void> logInsertNewPhoto() {
     debug('logInsertNewPhoto');
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('insert_new_photo'),
     );
   }
 
   Future<void> logTakePhoto() {
     debug('logTakePhoto');
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('take_photo'),
     );
   }
@@ -554,10 +562,12 @@ class AnalyticsService extends BaseAnalyticsService {
   Future<void> logViewImages({
     required int imagesCount,
   }) {
-    final parameters = sanitizeParameters({'images_count': imagesCount.toString()});
+    final parameters = sanitizeParameters({
+      'images_count': imagesCount.toString(),
+    });
     debug('logViewImages', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('view_images'),
       parameters: parameters,
     );
@@ -567,7 +577,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({});
     debug('logShareApp', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('share_app'),
       parameters: parameters,
     );
@@ -579,7 +589,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'option': option});
     debug('logShareStory', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('share_story'),
       parameters: parameters,
     );
@@ -589,7 +599,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({});
     debug('logClearPIN', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('clear_pin'),
       parameters: parameters,
     );
@@ -599,7 +609,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({});
     debug('logSetPIN', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('set_pin'),
       parameters: parameters,
     );
@@ -614,7 +624,7 @@ class AnalyticsService extends BaseAnalyticsService {
       'source': source,
     });
     debug('logUseGalleryTemplate', parameters);
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: 'use_gallery_template',
       parameters: parameters,
     );
@@ -626,7 +636,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logPutBackAllStories', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('put_back_all_stories'),
       parameters: parameters,
     );
@@ -638,7 +648,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logMoveAllStoriesToBin', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('move_all_stories_to_bin'),
       parameters: parameters,
     );
@@ -650,7 +660,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logUnpinAllStories', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('unpin_all_stories'),
       parameters: parameters,
     );
@@ -662,7 +672,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logPinAllStories', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('pin_all_stories'),
       parameters: parameters,
     );
@@ -674,7 +684,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logArchiveAllStories', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('archive_all_stories'),
       parameters: parameters,
     );
@@ -686,7 +696,7 @@ class AnalyticsService extends BaseAnalyticsService {
     final parameters = sanitizeParameters({'count': count.toString()});
     debug('logPermanentDeleteAllStories', parameters);
 
-    return FirebaseAnalytics.instance.logEvent(
+    return firebaseAnalytics.logEvent(
       name: sanitizeEventName('permanent_delete_all_stories'),
       parameters: parameters,
     );
@@ -702,8 +712,13 @@ class AnalyticsService extends BaseAnalyticsService {
       'day': story.day.toString(),
       'feeling': story.feeling,
       'tags_count': story.tags?.length.toString(),
-      'pages_count': (story.draftContent?.id != null ? story.draftContent : story.latestContent)?.richPages?.length
-          .toString(),
+      'pages_count':
+          (story.draftContent?.id != null
+                  ? story.draftContent
+                  : story.latestContent)
+              ?.richPages
+              ?.length
+              .toString(),
       'draft_saved': story.draftContent?.id != null ? 'true' : 'false',
       'preferred_show_day_count': story.preferences.showDayCount?.toString(),
     });

--- a/lib/core/services/analytics/analytics_user_propery_service.dart
+++ b/lib/core/services/analytics/analytics_user_propery_service.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:storypad/core/services/analytics/base_analytics_service.dart';
 import 'package:storypad/core/types/add_on_type.dart';
@@ -9,14 +8,15 @@ import 'package:storypad/core/types/time_format_option.dart';
 // Logging analytics events without user-identifiable information.
 class AnalyticsUserProperyService extends BaseAnalyticsService {
   AnalyticsUserProperyService._();
-  static AnalyticsUserProperyService get instance => AnalyticsUserProperyService._();
+  static AnalyticsUserProperyService get instance =>
+      AnalyticsUserProperyService._();
 
   Future<void> logSetLocale({
     required Locale newLocale,
   }) {
     debug('logSetLocale', {'value': newLocale.toLanguageTag()});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'locale',
       value: newLocale.toLanguageTag(),
     );
@@ -27,7 +27,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetColorSeedTheme', {'value': newColor.toString()});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       value: newColor?.toARGB32().toString() ?? 'default',
       name: 'color_seed',
     );
@@ -38,7 +38,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetThemeMode', {'value': newThemeMode.name});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'theme_mode',
       value: newThemeMode.name,
     );
@@ -49,7 +49,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetFontWeight', {'value': newFontWeight.value.toString()});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'font_weight',
       value: newFontWeight.value.toString(),
     );
@@ -60,7 +60,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetFontFamily', {'value': newFontFamily});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'font_family',
       value: newFontFamily,
     );
@@ -71,7 +71,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetFontSize', {'value': newFontSize?.name ?? 'system'});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'font_size',
       value: newFontSize?.name ?? 'system',
     );
@@ -82,7 +82,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetTimeFormat', {'value': timeFormat.name});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'time_format',
       value: timeFormat.label,
     );
@@ -92,9 +92,12 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
     required AddOnType addOn,
     required bool enabled,
   }) {
-    debug('logToggleAddOn', {'add_on': addOn.name, 'enabled': enabled.toString()});
+    debug('logToggleAddOn', {
+      'add_on': addOn.name,
+      'enabled': enabled.toString(),
+    });
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'add_on_${addOn.name}',
       value: enabled.toString(),
     );
@@ -115,11 +118,26 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
       'display_character_count': displayCharacterCount.toString(),
     });
 
-    await FirebaseAnalytics.instance.setUserProperty(name: 'list_show_time', value: showTime.toString());
-    await FirebaseAnalytics.instance.setUserProperty(name: 'list_show_page_count', value: showPageCount.toString());
-    await FirebaseAnalytics.instance.setUserProperty(name: 'list_show_tag_labels', value: showTagLabels.toString());
-    await FirebaseAnalytics.instance.setUserProperty(name: 'list_show_voice_count', value: showVoiceCount.toString());
-    await FirebaseAnalytics.instance.setUserProperty(name: 'list_char_count', value: displayCharacterCount.toString());
+    await firebaseAnalytics.setUserProperty(
+      name: 'list_show_time',
+      value: showTime.toString(),
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'list_show_page_count',
+      value: showPageCount.toString(),
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'list_show_tag_labels',
+      value: showTagLabels.toString(),
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'list_show_voice_count',
+      value: showVoiceCount.toString(),
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'list_char_count',
+      value: displayCharacterCount.toString(),
+    );
   }
 
   Future<void> logSetDefaultStoryPreferences({
@@ -133,9 +151,18 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
       'has_background': hasBackground.toString(),
     });
 
-    await FirebaseAnalytics.instance.setUserProperty(name: 'default_default_layout', value: defaultLayoutType);
-    await FirebaseAnalytics.instance.setUserProperty(name: 'default_has_color_seed', value: hasColorSeed.toString());
-    await FirebaseAnalytics.instance.setUserProperty(name: 'default_has_background', value: hasBackground.toString());
+    await firebaseAnalytics.setUserProperty(
+      name: 'default_default_layout',
+      value: defaultLayoutType,
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'default_has_color_seed',
+      value: hasColorSeed.toString(),
+    );
+    await firebaseAnalytics.setUserProperty(
+      name: 'default_has_background',
+      value: hasBackground.toString(),
+    );
   }
 
   Future<void> logSetAppLogo({
@@ -143,7 +170,7 @@ class AnalyticsUserProperyService extends BaseAnalyticsService {
   }) {
     debug('logSetAppLogo', {'value': newAppLogo?.name ?? 'default'});
 
-    return FirebaseAnalytics.instance.setUserProperty(
+    return firebaseAnalytics.setUserProperty(
       name: 'app_logo',
       value: newAppLogo?.name ?? 'default',
     );

--- a/lib/core/services/analytics/base_analytics_service.dart
+++ b/lib/core/services/analytics/base_analytics_service.dart
@@ -1,6 +1,12 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
+import 'package:storypad/core/utils/firebase_platform_support.dart';
 
 class BaseAnalyticsService {
+  FirebaseAnalytics get firebaseAnalytics => FirebasePlatformSupport.isSupported
+      ? FirebaseAnalytics.instance
+      : _NoOpFirebaseAnalytics();
+
   void debug(String logMethod, [Map<String, Object>? printData]) {
     if (printData != null) {
       debugPrint('🎯 $runtimeType#$logMethod -> $printData');
@@ -8,4 +14,9 @@ class BaseAnalyticsService {
       debugPrint('🎯 $runtimeType#$logMethod');
     }
   }
+}
+
+class _NoOpFirebaseAnalytics implements FirebaseAnalytics {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<void>.value();
 }

--- a/lib/core/services/firestore_storage_service.dart
+++ b/lib/core/services/firestore_storage_service.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:path/path.dart' as path;
 import 'package:storypad/core/services/logger/app_logger.dart';
 import 'package:storypad/core/types/support_directory_path.dart';
+import 'package:storypad/core/utils/firebase_platform_support.dart';
 
 enum FirestoreStorageState { success, connectionFailed, unauthorized, unknown }
 
@@ -34,21 +35,26 @@ class FirestoreStorageService {
   Map<String, dynamic>? _hash;
   Map<String, String>? _downloadUrlsByUrlPath;
 
-  final Map<String, Completer<FirestoreStorageResponse>> _downloadingFileByUrlPath = {};
+  final Map<String, Completer<FirestoreStorageResponse>>
+  _downloadingFileByUrlPath = {};
 
   Future<void> loadHash() async {
-    _hash = await rootBundle.loadString('assets/firestore_storage_map.json').then((jsonString) {
-      return json.decode(jsonString);
-    });
+    _hash = await rootBundle
+        .loadString('assets/firestore_storage_map.json')
+        .then((jsonString) {
+          return json.decode(jsonString);
+        });
   }
 
   // input: /relax_sounds/animal/forest_birds.svg"
   // output: /relax_sounds/animal/forest_birds-8ce3ba7e37ca67690cc3c180abfdffc8.svg"
   String getHashPath(String originalUrlPath) {
-    return _hash![originalUrlPath];
+    return _hash?[originalUrlPath] ?? originalUrlPath;
   }
 
   File? getCachedFile(String urlPath) {
+    if (_hash == null) return null;
+
     final String hashPath = getHashPath(urlPath);
     final String downloadPath = constructDeviceDownloadPath(hashPath);
     if (File(downloadPath).existsSync()) return File(downloadPath);
@@ -59,7 +65,10 @@ class FirestoreStorageService {
     _downloadUrlsByUrlPath ??= {};
 
     try {
-      if (_downloadUrlsByUrlPath?[urlPath] != null) return _downloadUrlsByUrlPath?[urlPath];
+      if (!FirebasePlatformSupport.isSupported) return null;
+      if (_downloadUrlsByUrlPath?[urlPath] != null) {
+        return _downloadUrlsByUrlPath?[urlPath];
+      }
 
       final storageRef = FirebaseStorage.instance.ref();
       final String hashPath = getHashPath(urlPath);
@@ -84,14 +93,29 @@ class FirestoreStorageService {
   Future<FirestoreStorageResponse> downloadFile(String urlPath) async {
     assert(urlPath.startsWith("/"));
 
+    if (!FirebasePlatformSupport.isSupported) {
+      final cachedFile = getCachedFile(urlPath);
+      return FirestoreStorageResponse(
+        file: cachedFile,
+        state: cachedFile != null
+            ? FirestoreStorageState.success
+            : FirestoreStorageState.unknown,
+      );
+    }
+
     final storageRef = FirebaseStorage.instance.ref();
     final String hashPath = getHashPath(urlPath);
     final String downloadPath = constructDeviceDownloadPath(hashPath);
 
-    if (File(downloadPath).existsSync()) return FirestoreStorageResponse(file: File(downloadPath));
-    if (!File(downloadPath).parent.existsSync()) await File(downloadPath).parent.create(recursive: true);
+    if (File(downloadPath).existsSync()) {
+      return FirestoreStorageResponse(file: File(downloadPath));
+    }
+    if (!File(downloadPath).parent.existsSync()) {
+      await File(downloadPath).parent.create(recursive: true);
+    }
 
-    if (_downloadingFileByUrlPath[urlPath] != null && !_downloadingFileByUrlPath[urlPath]!.isCompleted) {
+    if (_downloadingFileByUrlPath[urlPath] != null &&
+        !_downloadingFileByUrlPath[urlPath]!.isCompleted) {
       return _downloadingFileByUrlPath[urlPath]!.future;
     }
 
@@ -119,10 +143,16 @@ class FirestoreStorageService {
         );
       }
     } catch (e, s) {
-      AppLogger.error("🔴 FirestoreStorageService#downloadFile code: $e", stackTrace: s);
+      AppLogger.error(
+        "🔴 FirestoreStorageService#downloadFile code: $e",
+        stackTrace: s,
+      );
     }
 
-    response ??= FirestoreStorageResponse(file: null, state: FirestoreStorageState.unknown);
+    response ??= FirestoreStorageResponse(
+      file: null,
+      state: FirestoreStorageState.unknown,
+    );
     _downloadingFileByUrlPath[urlPath]?.complete(response);
     return response;
   }
@@ -135,16 +165,22 @@ class FirestoreStorageService {
   /// Returns a list of paths that were deleted.
   Future<List<String>> cleanupUnusedFiles() async {
     try {
-      final downloadDir = SupportDirectoryPath.downloaded_from_firestore.directory;
+      final downloadDir =
+          SupportDirectoryPath.downloaded_from_firestore.directory;
       if (!await downloadDir.exists()) return [];
 
       // {
       //   "/relax_sounds/water/ocean_waves-130d1d326a06fe0f21d4650a4f7065b7.txt",
       //   "/relax_sounds/water/droplets-ec36e00209a8cece33eef6f5c3f80e61.txt",
       // };
-      final validBasenames = (_hash ?? {}).values.map((e) => path.basename(e.toString())).toSet();
+      final validBasenames = (_hash ?? {}).values
+          .map((e) => path.basename(e.toString()))
+          .toSet();
 
-      final files = await downloadDir.list(recursive: true).where((entity) => entity is File).toList();
+      final files = await downloadDir
+          .list(recursive: true)
+          .where((entity) => entity is File)
+          .toList();
       final deletedFiles = <String>[];
 
       for (final fileEntity in files) {
@@ -163,10 +199,15 @@ class FirestoreStorageService {
         }
       }
 
-      AppLogger.info('$runtimeType#cleanupUnusedFiles ${deletedFiles.length} unused files removed');
+      AppLogger.info(
+        '$runtimeType#cleanupUnusedFiles ${deletedFiles.length} unused files removed',
+      );
       return deletedFiles;
     } catch (e, s) {
-      AppLogger.error('$runtimeType#cleanupUnusedFiles error: $e', stackTrace: s);
+      AppLogger.error(
+        '$runtimeType#cleanupUnusedFiles error: $e',
+        stackTrace: s,
+      );
       return [];
     }
   }

--- a/lib/core/services/local_auth_service.dart
+++ b/lib/core/services/local_auth_service.dart
@@ -1,3 +1,6 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:local_auth/local_auth.dart';
 
@@ -9,26 +12,48 @@ class LocalAuthService {
   List<BiometricType>? enrolledBiometrics;
 
   bool? get canCheckBiometrics => _canCheckBiometrics;
-  bool get enrolledBothFingerprintAndFace => enrolledFingerprint && enrolledFace;
-  bool get enrolledFingerprint => enrolledBiometrics?.contains(BiometricType.fingerprint) == true;
-  bool get enrolledFace => enrolledBiometrics?.contains(BiometricType.face) == true;
+  bool get enrolledBothFingerprintAndFace =>
+      enrolledFingerprint && enrolledFace;
+  bool get enrolledFingerprint =>
+      enrolledBiometrics?.contains(BiometricType.fingerprint) == true;
+  bool get enrolledFace =>
+      enrolledBiometrics?.contains(BiometricType.face) == true;
   bool get enrolledOtherBiometrics => _canCheckBiometrics == true;
 
   Future<void> load() async {
-    _isDeviceSupported = await auth.isDeviceSupported();
-    _canCheckBiometrics = await auth.canCheckBiometrics;
-    if (_isDeviceSupported!) enrolledBiometrics = await auth.getAvailableBiometrics();
+    if (Platform.isLinux) {
+      _isDeviceSupported = false;
+      _canCheckBiometrics = false;
+      enrolledBiometrics = [];
+      return;
+    }
+
+    try {
+      _isDeviceSupported = await auth.isDeviceSupported();
+      _canCheckBiometrics = await auth.canCheckBiometrics;
+      if (_isDeviceSupported!)
+        enrolledBiometrics = await auth.getAvailableBiometrics();
+    } on MissingPluginException catch (e) {
+      debugPrint('$runtimeType#load local_auth unsupported: ${e.toString()}');
+      _isDeviceSupported = false;
+      _canCheckBiometrics = false;
+      enrolledBiometrics = [];
+    }
   }
 
   Future<bool> authenticate({
     required String title,
   }) async {
+    if (Platform.isLinux) return false;
+
     await auth.stopAuthentication();
-    return auth.authenticate(localizedReason: title, persistAcrossBackgrounding: true).catchError(
-      (e) {
-        debugPrint('$runtimeType#authenticate failed: ${e.toString()}');
-        return false;
-      },
-    );
+    return auth
+        .authenticate(localizedReason: title, persistAcrossBackgrounding: true)
+        .catchError(
+          (e) {
+            debugPrint('$runtimeType#authenticate failed: ${e.toString()}');
+            return false;
+          },
+        );
   }
 }

--- a/lib/core/services/remote_config/remote_config_object.dart
+++ b/lib/core/services/remote_config/remote_config_object.dart
@@ -14,6 +14,8 @@ class _RemoteConfigObject<T> {
   );
 
   T get() {
+    if (!FirebasePlatformSupport.isSupported) return defaultValue;
+
     dynamic value;
 
     switch (type) {
@@ -30,10 +32,14 @@ class _RemoteConfigObject<T> {
         value = RemoteConfigService.instance.remoteConfig.getInt(key) as T;
         break;
       case _RemoteConfigValueType.json:
-        String result = RemoteConfigService.instance.remoteConfig.getString(key);
+        String result = RemoteConfigService.instance.remoteConfig.getString(
+          key,
+        );
 
         if (result.trim().isEmpty) {
-          debugPrint('🐛 [firebase/remote_config] Either $key is not set in Firebase or wrong content type.');
+          debugPrint(
+            '🐛 [firebase/remote_config] Either $key is not set in Firebase or wrong content type.',
+          );
           break;
         }
 
@@ -42,8 +48,11 @@ class _RemoteConfigObject<T> {
           value = json;
         } on FormatException catch (e) {
           debugPrint("$runtimeType#get() decode JSON failed $e");
-          if (!kIsWeb) {
-            FirebaseCrashlytics.instance.recordError(e, StackTrace.fromString(e.message));
+          if (!kIsWeb && FirebasePlatformSupport.isSupported) {
+            FirebaseCrashlytics.instance.recordError(
+              e,
+              StackTrace.fromString(e.message),
+            );
           }
         }
 

--- a/lib/core/services/remote_config/remote_config_service.dart
+++ b/lib/core/services/remote_config/remote_config_service.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:flutter/foundation.dart';
+import 'package:storypad/core/utils/firebase_platform_support.dart';
 
 part './remote_config_object.dart';
 
@@ -27,7 +28,8 @@ class RemoteConfigService {
   RemoteConfigService._();
 
   final Map<Type, void Function()> _listeners = {};
-  void clearListeners(String key, void Function() callback) => _listeners.clear();
+  void clearListeners(String key, void Function() callback) =>
+      _listeners.clear();
   void notifyListeners() {
     for (var callback in _listeners.values) {
       callback.call();
@@ -115,13 +117,17 @@ class RemoteConfigService {
       await remoteConfig.setConfigSettings(
         RemoteConfigSettings(
           fetchTimeout: const Duration(minutes: 5),
-          minimumFetchInterval: kDebugMode ? const Duration(minutes: 1) : const Duration(hours: 12),
+          minimumFetchInterval: kDebugMode
+              ? const Duration(minutes: 1)
+              : const Duration(hours: 12),
         ),
       );
 
       await remoteConfig.setDefaults({
         for (final element in _registeredKeys)
-          element.key: element.defaultValue is Map ? jsonEncode(element.defaultValue) : element.defaultValue,
+          element.key: element.defaultValue is Map
+              ? jsonEncode(element.defaultValue)
+              : element.defaultValue,
       });
 
       await remoteConfig.fetchAndActivate();

--- a/lib/core/utils/firebase_platform_support.dart
+++ b/lib/core/utils/firebase_platform_support.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+class FirebasePlatformSupport {
+  const FirebasePlatformSupport._();
+
+  static bool get isSupported => !Platform.isLinux;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,21 +2,33 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:easy_localization/easy_localization.dart' show EasyLocalization;
-import 'package:firebase_core/firebase_core.dart' show Firebase, FirebaseOptions;
-import 'package:macos_window_utils/window_manipulator.dart' show WindowManipulator;
+import 'package:firebase_core/firebase_core.dart'
+    show Firebase, FirebaseOptions;
+import 'package:macos_window_utils/window_manipulator.dart'
+    show WindowManipulator;
 import 'package:storypad/app.dart' show App;
-import 'package:storypad/core/initializers/app_lock_initializer.dart' show AppLockInitializer;
-import 'package:storypad/core/initializers/backup_initializer.dart' show BackupRepositoryInitializer;
-import 'package:storypad/core/initializers/constants_initializer.dart' show ConstantsInitializer;
-import 'package:storypad/core/initializers/database_initializer.dart' show DatabaseInitializer;
-import 'package:storypad/core/initializers/firebase_crashlytics_initializer.dart' show FirebaseCrashlyticsInitializer;
+import 'package:storypad/core/initializers/app_lock_initializer.dart'
+    show AppLockInitializer;
+import 'package:storypad/core/initializers/backup_initializer.dart'
+    show BackupRepositoryInitializer;
+import 'package:storypad/core/initializers/constants_initializer.dart'
+    show ConstantsInitializer;
+import 'package:storypad/core/initializers/database_initializer.dart'
+    show DatabaseInitializer;
+import 'package:storypad/core/initializers/firebase_crashlytics_initializer.dart'
+    show FirebaseCrashlyticsInitializer;
 import 'package:storypad/core/initializers/firebase_remote_config_initializer.dart'
     show FirebaseRemoteConfigInitializer;
 import 'package:storypad/core/initializers/firestore_storage_initializer.dart';
-import 'package:storypad/core/initializers/legacy_storypad_initializer.dart' show LegacyStoryPadInitializer;
-import 'package:storypad/core/initializers/licenses_initializer.dart' show LicensesInitializer;
-import 'package:storypad/core/initializers/onboarding_initializer.dart' show OnboardingInitializer;
-import 'package:storypad/core/initializers/theme_initializer.dart' show ThemeInitializer;
+import 'package:storypad/core/initializers/legacy_storypad_initializer.dart'
+    show LegacyStoryPadInitializer;
+import 'package:storypad/core/initializers/licenses_initializer.dart'
+    show LicensesInitializer;
+import 'package:storypad/core/initializers/onboarding_initializer.dart'
+    show OnboardingInitializer;
+import 'package:storypad/core/initializers/theme_initializer.dart'
+    show ThemeInitializer;
+import 'package:storypad/core/utils/firebase_platform_support.dart';
 import 'package:storypad/provider_scope.dart' show ProviderScope;
 import 'package:storypad/widgets/sp_splash_screen_wrapper.dart';
 
@@ -40,9 +52,11 @@ Future<void> _initializeApp({
   FirebaseOptions? firebaseOptions,
 }) async {
   // firebase initialize
-  await Firebase.initializeApp(options: firebaseOptions);
-  FirebaseCrashlyticsInitializer.call();
-  FirebaseRemoteConfigInitializer.call();
+  if (FirebasePlatformSupport.isSupported) {
+    await Firebase.initializeApp(options: firebaseOptions);
+    FirebaseCrashlyticsInitializer.call();
+    FirebaseRemoteConfigInitializer.call();
+  }
 
   // core
   await EasyLocalization.ensureInitialized();
@@ -65,7 +79,9 @@ Future<void> _initializeApp({
   }
 
   // initialize & cleanup old assets
-  await FirestoreStorageInitializer.call();
+  if (FirebasePlatformSupport.isSupported) {
+    await FirestoreStorageInitializer.call();
+  }
 
   LicensesInitializer.call();
 }

--- a/linux/.gitignore
+++ b/linux/.gitignore
@@ -1,0 +1,1 @@
+flutter/ephemeral

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Project-level configuration.
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# The name of the executable created for the application. Change this to change
+# the on-disk name of your application.
+set(BINARY_NAME "storypad")
+# The unique GTK application identifier for this application. See:
+# https://wiki.gnome.org/HowDoI/ChooseApplicationID
+set(APPLICATION_ID "com.juniorise.storypad")
+
+# Explicitly opt in to modern CMake behaviors to avoid warnings with recent
+# versions of CMake.
+cmake_policy(SET CMP0063 NEW)
+
+# Load bundled libraries from the lib/ directory relative to the binary.
+set(CMAKE_INSTALL_RPATH "$ORIGIN/lib")
+
+# Root filesystem for cross-building.
+if(FLUTTER_TARGET_PLATFORM_SYSROOT)
+  set(CMAKE_SYSROOT ${FLUTTER_TARGET_PLATFORM_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH ${CMAKE_SYSROOT})
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+# Define build configuration options.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE "Debug" CACHE
+    STRING "Flutter build mode" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Profile" "Release")
+endif()
+
+# Compilation settings that should be applied to most targets.
+#
+# Be cautious about adding new options here, as plugins use this function by
+# default. In most cases, you should add new options to specific targets instead
+# of modifying this function.
+function(APPLY_STANDARD_SETTINGS TARGET)
+  target_compile_features(${TARGET} PUBLIC cxx_std_14)
+  target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+  target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
+  target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
+endfunction()
+
+# Flutter library and tool build rules.
+set(FLUTTER_MANAGED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/flutter")
+add_subdirectory(${FLUTTER_MANAGED_DIR})
+
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+
+# Application build; see runner/CMakeLists.txt.
+add_subdirectory("runner")
+
+# Run the Flutter tool portions of the build. This must not be removed.
+add_dependencies(${BINARY_NAME} flutter_assemble)
+
+# Only the install-generated bundle's copy of the executable will launch
+# correctly, since the resources must in the right relative locations. To avoid
+# people trying to run the unbundled copy, put it in a subdirectory instead of
+# the default top-level location.
+set_target_properties(${BINARY_NAME}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/intermediates_do_not_run"
+)
+
+
+# Generated plugin build rules, which manage building the plugins and adding
+# them to the application.
+include(flutter/generated_plugins.cmake)
+
+
+# === Installation ===
+# Always install the relocatable bundle under the build directory. Do not
+# install to CMAKE's default or a cached /usr/local prefix (causes permission
+# errors and breaks `flutter build linux`).
+set(BUILD_BUNDLE_DIR "${PROJECT_BINARY_DIR}/bundle")
+set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH
+  "Path prepended to install destinations, inside the build output." FORCE)
+
+# Start with a clean build bundle directory every time.
+install(CODE "
+  file(REMOVE_RECURSE \"${BUILD_BUNDLE_DIR}/\")
+  " COMPONENT Runtime)
+
+set(INSTALL_BUNDLE_DATA_DIR "${CMAKE_INSTALL_PREFIX}/data")
+set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+
+install(TARGETS ${BINARY_NAME} RUNTIME DESTINATION "."
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_ICU_DATA_FILE}" DESTINATION "${INSTALL_BUNDLE_DATA_DIR}"
+  COMPONENT Runtime)
+
+install(FILES "${FLUTTER_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
+foreach(bundled_library ${PLUGIN_BUNDLED_LIBRARIES})
+  install(FILES "${bundled_library}"
+    DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endforeach(bundled_library)
+
+# Copy the native assets provided by the build.dart from all packages.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/linux/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+   DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+   COMPONENT Runtime)
+
+# Fully re-copy the assets directory on each build to avoid having stale files
+# from a previous install.
+set(FLUTTER_ASSET_DIR_NAME "flutter_assets")
+install(CODE "
+  file(REMOVE_RECURSE \"${INSTALL_BUNDLE_DATA_DIR}/${FLUTTER_ASSET_DIR_NAME}\")
+  " COMPONENT Runtime)
+install(DIRECTORY "${PROJECT_BUILD_DIR}/${FLUTTER_ASSET_DIR_NAME}"
+  DESTINATION "${INSTALL_BUNDLE_DATA_DIR}" COMPONENT Runtime)
+
+# Install the AOT library on non-Debug builds only.
+if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
+  install(FILES "${AOT_LIBRARY}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+    COMPONENT Runtime)
+endif()

--- a/linux/flutter/CMakeLists.txt
+++ b/linux/flutter/CMakeLists.txt
@@ -1,0 +1,88 @@
+# This file controls Flutter-level build steps. It should not be edited.
+cmake_minimum_required(VERSION 3.10)
+
+set(EPHEMERAL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ephemeral")
+
+# Configuration provided via flutter tool.
+include(${EPHEMERAL_DIR}/generated_config.cmake)
+
+# TODO: Move the rest of this into files in ephemeral. See
+# https://github.com/flutter/flutter/issues/57146.
+
+# Serves the same purpose as list(TRANSFORM ... PREPEND ...),
+# which isn't available in 3.10.
+function(list_prepend LIST_NAME PREFIX)
+    set(NEW_LIST "")
+    foreach(element ${${LIST_NAME}})
+        list(APPEND NEW_LIST "${PREFIX}${element}")
+    endforeach(element)
+    set(${LIST_NAME} "${NEW_LIST}" PARENT_SCOPE)
+endfunction()
+
+# === Flutter Library ===
+# System-level dependencies.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(GTK REQUIRED IMPORTED_TARGET gtk+-3.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(GIO REQUIRED IMPORTED_TARGET gio-2.0)
+
+set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/libflutter_linux_gtk.so")
+
+# Published to parent scope for install step.
+set(FLUTTER_LIBRARY ${FLUTTER_LIBRARY} PARENT_SCOPE)
+set(FLUTTER_ICU_DATA_FILE "${EPHEMERAL_DIR}/icudtl.dat" PARENT_SCOPE)
+set(PROJECT_BUILD_DIR "${PROJECT_DIR}/build/" PARENT_SCOPE)
+set(AOT_LIBRARY "${PROJECT_DIR}/build/lib/libapp.so" PARENT_SCOPE)
+
+list(APPEND FLUTTER_LIBRARY_HEADERS
+  "fl_basic_message_channel.h"
+  "fl_binary_codec.h"
+  "fl_binary_messenger.h"
+  "fl_dart_project.h"
+  "fl_engine.h"
+  "fl_json_message_codec.h"
+  "fl_json_method_codec.h"
+  "fl_message_codec.h"
+  "fl_method_call.h"
+  "fl_method_channel.h"
+  "fl_method_codec.h"
+  "fl_method_response.h"
+  "fl_plugin_registrar.h"
+  "fl_plugin_registry.h"
+  "fl_standard_message_codec.h"
+  "fl_standard_method_codec.h"
+  "fl_string_codec.h"
+  "fl_value.h"
+  "fl_view.h"
+  "flutter_linux.h"
+)
+list_prepend(FLUTTER_LIBRARY_HEADERS "${EPHEMERAL_DIR}/flutter_linux/")
+add_library(flutter INTERFACE)
+target_include_directories(flutter INTERFACE
+  "${EPHEMERAL_DIR}"
+)
+target_link_libraries(flutter INTERFACE "${FLUTTER_LIBRARY}")
+target_link_libraries(flutter INTERFACE
+  PkgConfig::GTK
+  PkgConfig::GLIB
+  PkgConfig::GIO
+)
+add_dependencies(flutter flutter_assemble)
+
+# === Flutter tool backend ===
+# _phony_ is a non-existent file to force this command to run every time,
+# since currently there's no way to get a full input/output list from the
+# flutter tool.
+add_custom_command(
+  OUTPUT ${FLUTTER_LIBRARY} ${FLUTTER_LIBRARY_HEADERS}
+    ${CMAKE_CURRENT_BINARY_DIR}/_phony_
+  COMMAND ${CMAKE_COMMAND} -E env
+    ${FLUTTER_TOOL_ENVIRONMENT}
+    "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
+)
+add_custom_target(flutter_assemble DEPENDS
+  "${FLUTTER_LIBRARY}"
+  ${FLUTTER_LIBRARY_HEADERS}
+)

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -1,0 +1,39 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#include "generated_plugin_registrant.h"
+
+#include <dynamic_color/dynamic_color_plugin.h>
+#include <emoji_picker_flutter/emoji_picker_flutter_plugin.h>
+#include <file_selector_linux/file_selector_plugin.h>
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
+#include <record_linux/record_linux_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
+
+void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
+  dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
+  g_autoptr(FlPluginRegistrar) emoji_picker_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "EmojiPickerFlutterPlugin");
+  emoji_picker_flutter_plugin_register_with_registrar(emoji_picker_flutter_registrar);
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) objectbox_flutter_libs_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ObjectboxFlutterLibsPlugin");
+  objectbox_flutter_libs_plugin_register_with_registrar(objectbox_flutter_libs_registrar);
+  g_autoptr(FlPluginRegistrar) record_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
+  record_linux_plugin_register_with_registrar(record_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
+}

--- a/linux/flutter/generated_plugin_registrant.h
+++ b/linux/flutter/generated_plugin_registrant.h
@@ -1,0 +1,15 @@
+//
+//  Generated file. Do not edit.
+//
+
+// clang-format off
+
+#ifndef GENERATED_PLUGIN_REGISTRANT_
+#define GENERATED_PLUGIN_REGISTRANT_
+
+#include <flutter_linux/flutter_linux.h>
+
+// Registers Flutter plugins.
+void fl_register_plugins(FlPluginRegistry* registry);
+
+#endif  // GENERATED_PLUGIN_REGISTRANT_

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -1,0 +1,30 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+  dynamic_color
+  emoji_picker_flutter
+  file_selector_linux
+  flutter_secure_storage_linux
+  objectbox_flutter_libs
+  record_linux
+  url_launcher_linux
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/linux plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/linux plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/linux/runner/CMakeLists.txt
+++ b/linux/runner/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.13)
+project(runner LANGUAGES CXX)
+
+# Define the application target. To change its name, change BINARY_NAME in the
+# top-level CMakeLists.txt, not the value here, or `flutter run` will no longer
+# work.
+#
+# Any new source files that you add to the application should be added here.
+add_executable(${BINARY_NAME}
+  "main.cc"
+  "my_application.cc"
+  "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"
+)
+
+# Apply the standard set of build settings. This can be removed for applications
+# that need different build settings.
+apply_standard_settings(${BINARY_NAME})
+
+# Add preprocessor definitions for the application ID.
+add_definitions(-DAPPLICATION_ID="${APPLICATION_ID}")
+
+# Add dependency libraries. Add any application-specific dependencies here.
+target_link_libraries(${BINARY_NAME} PRIVATE flutter)
+target_link_libraries(${BINARY_NAME} PRIVATE PkgConfig::GTK)
+
+target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")

--- a/linux/runner/main.cc
+++ b/linux/runner/main.cc
@@ -1,0 +1,6 @@
+#include "my_application.h"
+
+int main(int argc, char** argv) {
+  g_autoptr(MyApplication) app = my_application_new();
+  return g_application_run(G_APPLICATION(app), argc, argv);
+}

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -1,0 +1,148 @@
+#include "my_application.h"
+
+#include <flutter_linux/flutter_linux.h>
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+
+#include "flutter/generated_plugin_registrant.h"
+
+struct _MyApplication {
+  GtkApplication parent_instance;
+  char** dart_entrypoint_arguments;
+};
+
+G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
+
+// Called when first Flutter frame received.
+static void first_frame_cb(MyApplication* self, FlView* view) {
+  gtk_widget_show(gtk_widget_get_toplevel(GTK_WIDGET(view)));
+}
+
+// Implements GApplication::activate.
+static void my_application_activate(GApplication* application) {
+  MyApplication* self = MY_APPLICATION(application);
+  GtkWindow* window =
+      GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
+
+  // Use a header bar when running in GNOME as this is the common style used
+  // by applications and is the setup most users will be using (e.g. Ubuntu
+  // desktop).
+  // If running on X and not using GNOME then just use a traditional title bar
+  // in case the window manager does more exotic layout, e.g. tiling.
+  // If running on Wayland assume the header bar will work (may need changing
+  // if future cases occur).
+  gboolean use_header_bar = TRUE;
+#ifdef GDK_WINDOWING_X11
+  GdkScreen* screen = gtk_window_get_screen(window);
+  if (GDK_IS_X11_SCREEN(screen)) {
+    const gchar* wm_name = gdk_x11_screen_get_window_manager_name(screen);
+    if (g_strcmp0(wm_name, "GNOME Shell") != 0) {
+      use_header_bar = FALSE;
+    }
+  }
+#endif
+  if (use_header_bar) {
+    GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
+    gtk_widget_show(GTK_WIDGET(header_bar));
+    gtk_header_bar_set_title(header_bar, "storypad");
+    gtk_header_bar_set_show_close_button(header_bar, TRUE);
+    gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
+  } else {
+    gtk_window_set_title(window, "storypad");
+  }
+
+  gtk_window_set_default_size(window, 1280, 720);
+
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  fl_dart_project_set_dart_entrypoint_arguments(
+      project, self->dart_entrypoint_arguments);
+
+  FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000
+  // for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
+  gtk_widget_show(GTK_WIDGET(view));
+  gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
+
+  // Show the window when Flutter renders.
+  // Requires the view to be realized so we can start rendering.
+  g_signal_connect_swapped(view, "first-frame", G_CALLBACK(first_frame_cb),
+                           self);
+  gtk_widget_realize(GTK_WIDGET(view));
+
+  fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  gtk_widget_grab_focus(GTK_WIDGET(view));
+}
+
+// Implements GApplication::local_command_line.
+static gboolean my_application_local_command_line(GApplication* application,
+                                                  gchar*** arguments,
+                                                  int* exit_status) {
+  MyApplication* self = MY_APPLICATION(application);
+  // Strip out the first argument as it is the binary name.
+  self->dart_entrypoint_arguments = g_strdupv(*arguments + 1);
+
+  g_autoptr(GError) error = nullptr;
+  if (!g_application_register(application, nullptr, &error)) {
+    g_warning("Failed to register: %s", error->message);
+    *exit_status = 1;
+    return TRUE;
+  }
+
+  g_application_activate(application);
+  *exit_status = 0;
+
+  return TRUE;
+}
+
+// Implements GApplication::startup.
+static void my_application_startup(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application startup.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->startup(application);
+}
+
+// Implements GApplication::shutdown.
+static void my_application_shutdown(GApplication* application) {
+  // MyApplication* self = MY_APPLICATION(object);
+
+  // Perform any actions required at application shutdown.
+
+  G_APPLICATION_CLASS(my_application_parent_class)->shutdown(application);
+}
+
+// Implements GObject::dispose.
+static void my_application_dispose(GObject* object) {
+  MyApplication* self = MY_APPLICATION(object);
+  g_clear_pointer(&self->dart_entrypoint_arguments, g_strfreev);
+  G_OBJECT_CLASS(my_application_parent_class)->dispose(object);
+}
+
+static void my_application_class_init(MyApplicationClass* klass) {
+  G_APPLICATION_CLASS(klass)->activate = my_application_activate;
+  G_APPLICATION_CLASS(klass)->local_command_line =
+      my_application_local_command_line;
+  G_APPLICATION_CLASS(klass)->startup = my_application_startup;
+  G_APPLICATION_CLASS(klass)->shutdown = my_application_shutdown;
+  G_OBJECT_CLASS(klass)->dispose = my_application_dispose;
+}
+
+static void my_application_init(MyApplication* self) {}
+
+MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
+  return MY_APPLICATION(g_object_new(my_application_get_type(),
+                                     "application-id", APPLICATION_ID, "flags",
+                                     G_APPLICATION_NON_UNIQUE, nullptr));
+}

--- a/linux/runner/my_application.h
+++ b/linux/runner/my_application.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_MY_APPLICATION_H_
+#define FLUTTER_MY_APPLICATION_H_
+
+#include <gtk/gtk.h>
+
+G_DECLARE_FINAL_TYPE(MyApplication,
+                     my_application,
+                     MY,
+                     APPLICATION,
+                     GtkApplication)
+
+/**
+ * my_application_new:
+ *
+ * Creates a new Flutter-based application.
+ *
+ * Returns: a new #MyApplication.
+ */
+MyApplication* my_application_new();
+
+#endif  // FLUTTER_MY_APPLICATION_H_


### PR DESCRIPTION
### Summary

This PR adds a Linux desktop target and makes the app start on Linux by skipping FlutterFire and other plugins that have no native Linux implementation, while keeping local data (ObjectBox) and default remote-config values.

### Changes

- **Linux runner**: add generated `linux/` project and fix CMake install so the build outputs a relocatable bundle under `build/linux/.../bundle/` (no install to `/usr/local`).
- **Firebase / analytics**: gate initialization and usage behind `FirebasePlatformSupport` (disabled on Linux); analytics uses a no-op backend on Linux; remote config returns built-in defaults; Crashlytics falls back to logging only when Firebase is off.
- **Storage**: avoid calling Firebase Storage on Linux; return a safe outcome when cloud download is unavailable.
- **Environment**: fall back for `path_provider` when the documents/support directories are unavailable; disable `local_auth` channel calls on Linux (no biometric plugin).

### How to test

```bash
flutter build linux
./build/linux/x64/release/bundle/storypad
```

### Notes

- GDK/GTK theme warnings on some setups are environmental and unrelated to app logic.
- This is intended for a **personal fork / experimental Linux build**; full parity with mobile (Firebase, biometrics, cloud assets) is not claimed.