### PR TITLE
Split entries by year in view tag page

### DIFF
--- a/lib/views/home/local_widgets/home_scroll_info.dart
+++ b/lib/views/home/local_widgets/home_scroll_info.dart
@@ -168,12 +168,20 @@ class _HomeScrollInfo {
 
       // Find all currently visible keys
       List<int> visibleIndices = [];
+      List<int> visiblePinnedIndices = [];
+
       for (int i = 0; i < allStoryKeys.length; i++) {
         if (allStoryKeys[i].currentContext != null) {
-          visibleIndices.add(i);
+          if (i < pinnedStoryKeys.length) {
+            visiblePinnedIndices.add(i);
+          } else {
+            visibleIndices.add(i);
+          }
         }
       }
 
+      // Always scroll to normal stories first, only scroll to pinned if no normal story is visible.
+      if (visibleIndices.isEmpty) visibleIndices = visiblePinnedIndices;
       if (visibleIndices.isEmpty) break;
 
       // Determine direction and find nearest visible key
@@ -182,6 +190,7 @@ class _HomeScrollInfo {
 
       // Jump to nearest visible key (no animation) to trigger rendering of more items
       final nearestKey = allStoryKeys[nearestIndex];
+
       if (nearestKey.currentContext != null) {
         await Scrollable.ensureVisible(
           nearestKey.currentContext!,

--- a/lib/views/tags/show/show_tag_content.dart
+++ b/lib/views/tags/show/show_tag_content.dart
@@ -7,18 +7,23 @@ class _ShowTagContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SpStoryListMultiEditWrapper.withListener(
-      builder: (BuildContext context, SpStoryListMultiEditWrapperState state) {
-        return PopScope(
-          canPop: !state.editing,
-          onPopInvokedWithResult: (didPop, result) => viewModel.onPopInvokedWithResult(didPop, result, context),
-          child: buildScaffold(context, state),
-        );
-      },
+    final years = viewModel.years;
+
+    return DefaultTabController(
+      length: years?.length ?? 1,
+      child: SpStoryListMultiEditWrapper.withListener(
+        builder: (BuildContext context, SpStoryListMultiEditWrapperState state) {
+          return PopScope(
+            canPop: !state.editing,
+            onPopInvokedWithResult: (didPop, result) => viewModel.onPopInvokedWithResult(didPop, result, context),
+            child: buildScaffold(context, state, years),
+          );
+        },
+      ),
     );
   }
 
-  Widget buildScaffold(BuildContext context, SpStoryListMultiEditWrapperState state) {
+  Widget buildScaffold(BuildContext context, SpStoryListMultiEditWrapperState state, List<int>? years) {
     return Scaffold(
       appBar: AppBar(
         title: buildTitle(context),
@@ -29,6 +34,15 @@ class _ShowTagContent extends StatelessWidget {
             onPressed: () => viewModel.goToFilterPage(context),
           ),
         ],
+        bottom: years == null
+            ? null
+            : TabBar(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                isScrollable: true,
+                tabAlignment: TabAlignment.start,
+                onTap: (_) => state.turnOffEditing(),
+                tabs: years.map((year) => Tab(text: year.toString())).toList(),
+              ),
       ),
       bottomNavigationBar: buildBottomNavigationBar(context, state),
       floatingActionButtonLocation: SpFabLocation.endFloat(context),
@@ -37,11 +51,23 @@ class _ShowTagContent extends StatelessWidget {
         child: const Icon(SpIcons.newStory),
         onPressed: () => viewModel.goToNewPage(context),
       ),
-      body: SpStoryList.withQuery(
-        key: ValueKey(viewModel.editedKey),
-        viewOnly: viewModel.params.storyViewOnly,
-        filter: viewModel.filter,
-      ),
+      body: buildBody(years),
+    );
+  }
+
+  Widget buildBody(List<int>? years) {
+    if (years == null) {
+      return const Center(child: CircularProgressIndicator.adaptive());
+    }
+
+    return TabBarView(
+      children: years.map((year) {
+        return SpStoryList.withQuery(
+          key: ValueKey('${viewModel.editedKey}_$year'),
+          viewOnly: viewModel.params.storyViewOnly,
+          filter: viewModel.filter.copyWith(years: {year}),
+        );
+      }).toList(),
     );
   }
 

--- a/lib/views/tags/show/show_tag_view.dart
+++ b/lib/views/tags/show/show_tag_view.dart
@@ -7,6 +7,7 @@ import 'package:storypad/widgets/story_list/sp_story_list_multi_edit_wrapper.dar
 import 'package:storypad/widgets/base_view/view_model_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:storypad/core/databases/models/tag_db_model.dart';
+import 'package:storypad/core/objects/search_filter_object.dart';
 import 'package:storypad/widgets/base_view/base_route.dart';
 import 'package:storypad/widgets/story_list/sp_story_list.dart';
 

--- a/lib/views/tags/show/show_tag_view_model.dart
+++ b/lib/views/tags/show/show_tag_view_model.dart
@@ -2,6 +2,7 @@ import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:storypad/core/databases/models/story_db_model.dart';
 import 'package:storypad/core/types/path_type.dart';
 import 'package:storypad/providers/tags_provider.dart';
 import 'package:storypad/views/home/home_view.dart';
@@ -20,15 +21,26 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
     required this.params,
   }) {
     _tag = params.tag;
+    load();
   }
 
   late TagDbModel _tag;
   TagDbModel get tag => _tag;
 
   int editedKey = 0;
+  List<int>? years;
+
+  Future<void> load() async {
+    years = await StoryDbModel.db
+        .getStoryCountsByYear(filters: filter.toDatabaseFilter())
+        .then((map) => map.keys.toList()..sort((a, b) => b.compareTo(a)));
+
+    notifyListeners();
+  }
+
   void refreshList() {
     editedKey++;
-    notifyListeners();
+    load();
   }
 
   late SearchFilterObject filter = SearchFilterObject(
@@ -49,7 +61,7 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
       _tag = editedTag;
     }
 
-    notifyListeners();
+    await load();
   }
 
   Future<void> goToNewPage(BuildContext context) async {
@@ -58,8 +70,7 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
       initialTagIds: [tag.id],
     ).push(context);
 
-    editedKey += 1;
-    notifyListeners();
+    refreshList();
 
     Future.delayed(const Duration(seconds: 1)).then((_) {
       HomeView.reload(debugSource: '$runtimeType#goToNewPage');
@@ -76,7 +87,7 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
 
     if (result is SearchFilterObject) {
       filter = result;
-      notifyListeners();
+      await load();
     }
   }
 


### PR DESCRIPTION
This will reduce memory usage as well as make it easy to follow the app core yearly journal flow.