### PR TITLE
Fix media export OOM crash and harden asset download flow

### DIFF
--- a/lib/core/services/google_drive_asset_downloader_service.dart
+++ b/lib/core/services/google_drive_asset_downloader_service.dart
@@ -11,10 +11,19 @@ class GoogleDriveAssetDownloaderException {
   final String message;
   final StackTrace? stackTrace;
 
+  /// HTTP status code when the failure originated from an HTTP response
+  /// (e.g. 401/403 auth, 404 missing). `null` for non-HTTP failures.
+  final int? statusCode;
+
   GoogleDriveAssetDownloaderException(
     this.message, {
     this.stackTrace,
+    this.statusCode,
   });
+
+  /// Auth-related failures affect every download for the current session, so
+  /// callers should stop rather than retry the remaining assets.
+  bool get isAuthError => statusCode == 401 || statusCode == 403;
 
   @override
   String toString() => 'GoogleDriveAssetDownloaderException: $message';
@@ -149,11 +158,15 @@ class GoogleDriveAssetDownloaderService {
       if (response.statusCode == 401) {
         throw GoogleDriveAssetDownloaderException(
           'Authentication expired. Please sign in again to download this asset.',
+          statusCode: 401,
         );
       }
 
       if (response.statusCode == 403) {
-        throw GoogleDriveAssetDownloaderException('Access denied. Please sign in to download this asset.');
+        throw GoogleDriveAssetDownloaderException(
+          'Access denied. Please sign in to download this asset.',
+          statusCode: 403,
+        );
       }
 
       // Handle other HTTP errors
@@ -161,12 +174,14 @@ class GoogleDriveAssetDownloaderService {
         FirebaseCrashlytics.instance.log('$runtimeType#_downloadFromUrl: 404 — $embedLink');
         throw GoogleDriveAssetDownloaderException(
           'Asset not found (404). Status: 404',
+          statusCode: 404,
         );
       }
 
       if (response.statusCode != 200) {
         throw GoogleDriveAssetDownloaderException(
           'Failed to download asset. Status: ${response.statusCode}',
+          statusCode: response.statusCode,
         );
       }
 
@@ -178,22 +193,29 @@ class GoogleDriveAssetDownloaderService {
         );
       }
 
-      // Save file to local storage
+      // Save file to local storage using an atomic write: write the full bytes
+      // to a temp file first, then rename it into place. rename() is atomic on
+      // the same filesystem, so the canonical path only ever appears
+      // fully-written — a crash/kill mid-write can't leave a truncated file
+      // that would later be counted as "downloaded" and shown as a corrupt image.
       final downloadedFile = File(localFilePath);
-      await downloadedFile.create(recursive: true);
-      await downloadedFile.writeAsBytes(response.bodyBytes);
+      final tempFile = File('$localFilePath.download');
+
+      await tempFile.create(recursive: true);
+      await tempFile.writeAsBytes(response.bodyBytes, flush: true);
+      await tempFile.rename(localFilePath);
 
       debugPrint('✅ Asset downloaded successfully: $embedLink');
       return downloadedFile.path;
     } catch (e) {
-      // Clean up partial downloads
-      final downloadedFile = File(localFilePath);
-
-      if (downloadedFile.existsSync()) {
-        try {
-          downloadedFile.deleteSync();
-        } catch (deleteError) {
-          debugPrint('⚠️ Failed to clean up partial download: $deleteError');
+      // Clean up partial downloads (both the temp file and any stale target).
+      for (final file in [File('$localFilePath.download'), File(localFilePath)]) {
+        if (file.existsSync()) {
+          try {
+            file.deleteSync();
+          } catch (deleteError) {
+            debugPrint('⚠️ Failed to clean up partial download: $deleteError');
+          }
         }
       }
 

--- a/lib/core/services/storage/storage_info_service.dart
+++ b/lib/core/services/storage/storage_info_service.dart
@@ -17,6 +17,18 @@ class StorageInfoService {
     return result;
   }
 
+  /// Suffix used for in-progress/atomic asset downloads (see
+  /// GoogleDriveAssetDownloaderService). A leftover `*.download` file means a
+  /// download was interrupted; it's never a valid asset.
+  static const String downloadTempSuffix = '.download';
+
+  /// Asset directories where interrupted downloads can leave orphaned
+  /// `*.download` temp files.
+  static const List<SupportDirectoryPath> assetDirectories = [
+    SupportDirectoryPath.images,
+    SupportDirectoryPath.audio,
+  ];
+
   /// Deletes all files inside [path]'s directory without removing the directory itself.
   Future<void> clearDirectory(SupportDirectoryPath path) async {
     final dir = path.directory;
@@ -26,6 +38,23 @@ class StorageInfoService {
       try {
         await entity.delete(recursive: true);
       } catch (_) {}
+    }
+  }
+
+  /// Deletes orphaned `*.download` temp files left behind by interrupted asset
+  /// downloads. These are never valid assets, so removing them is always safe.
+  Future<void> clearOrphanedDownloads() async {
+    for (final path in assetDirectories) {
+      final dir = path.directory;
+      if (!await dir.exists()) continue;
+
+      await for (final entity in dir.list(recursive: false)) {
+        if (entity is File && entity.path.endsWith(downloadTempSuffix)) {
+          try {
+            await entity.delete();
+          } catch (_) {}
+        }
+      }
     }
   }
 

--- a/lib/views/import_export/export_assets/export_assets_view_model.dart
+++ b/lib/views/import_export/export_assets/export_assets_view_model.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -32,6 +31,12 @@ class ExportAssetsViewModel extends ChangeNotifier with DisposeAwareMixin {
   bool _isDownloading = false;
   bool get isDownloading => _isDownloading;
 
+  /// Assets that couldn't be included in the last export — either nothing was
+  /// available to download (not backed up for the current user) or the download
+  /// failed (e.g. the Google Drive file is gone — 404). We export as much as
+  /// possible and report the rest as skipped.
+  final List<AssetDbModel> _skippedAssets = [];
+
   Map<AssetType, int> get assetCountsByType {
     final counts = <AssetType, int>{};
     for (final type in AssetType.values) {
@@ -58,8 +63,17 @@ class ExportAssetsViewModel extends ChangeNotifier with DisposeAwareMixin {
     notifyListeners();
   }
 
-  Future<void> downloadAssets(BuildContext context) async {
+  /// Downloads any assets that aren't available locally so they can be exported.
+  ///
+  /// Individual failures (e.g. a missing Google Drive file — 404) are skipped
+  /// and collected in [_skippedAssets] so we can still "export as much as
+  /// possible". Returns `false` only on an auth error (401/403), which affects
+  /// every download and means the caller should abort; disposal mid-download is
+  /// a graceful stop and returns `true`.
+  Future<bool> downloadAssets(BuildContext context) async {
     final currentUser = context.read<BackupProvider>().currentGoogleUser;
+
+    _skippedAssets.clear();
 
     // Download assets first if needed
     final assetsToDownload = _assets.where((asset) {
@@ -67,100 +81,102 @@ class ExportAssetsViewModel extends ChangeNotifier with DisposeAwareMixin {
       return file == null || !file.existsSync();
     }).toList();
 
-    if (assetsToDownload.isNotEmpty) {
-      _isDownloading = true;
-      notifyListeners();
+    if (assetsToDownload.isEmpty) return true;
 
-      for (int i = 0; i < assetsToDownload.length; i++) {
-        final asset = assetsToDownload[i];
-        notifyListeners();
+    _isDownloading = true;
+    notifyListeners();
 
-        // Ignore files not uploaded to Google Drive
+    try {
+      for (final asset in assetsToDownload) {
+        // Stop gracefully if the screen was popped (view model disposed)
+        // mid-download. Not a failure — just halt where we are.
+        if (disposed) break;
+
+        // Not uploaded to Google Drive for this user — nothing to download.
         if (currentUser == null || !asset.isGoogleDriveUploadedFor(currentUser.email)) {
+          _skippedAssets.add(asset);
           continue;
         }
 
         try {
           await GoogleDriveAssetDownloaderService().downloadAsset(asset: asset, currentUser: currentUser);
         } catch (e) {
-          if (context.mounted) {
-            MessengerService.of(context).showError('${asset.relativeLocalFilePath}: ${e.toString()}');
+          // Auth errors affect every remaining download — surface and abort.
+          if (e is GoogleDriveAssetDownloaderException && e.isAuthError) {
+            if (context.mounted) MessengerService.of(context).showError(e.message);
+            return false;
           }
-          return;
+
+          // Otherwise skip this asset and keep going.
+          _skippedAssets.add(asset);
         }
+
+        // Refresh the "downloaded X/Y" progress shown in the UI after each asset.
+        notifyListeners();
       }
 
+      return true;
+    } finally {
+      // Always reset, even on early return/error, so the button doesn't get
+      // stuck at "Downloading...".
       _isDownloading = false;
       notifyListeners();
-
-      if (!context.mounted) return;
     }
   }
 
   Future<void> exportAssets(BuildContext context) async {
-    await downloadAssets(context);
+    // Download what we can. Per-asset failures (e.g. 404) are skipped and
+    // collected in [_skippedAssets]; only an auth error aborts the whole export.
+    final downloaded = await downloadAssets(context);
+    if (!downloaded) return;
+
+    // Remove any archives left behind by previously crashed/cancelled exports
+    // so the cache doesn't keep growing across attempts.
+    await _cleanUpStaleExports();
+
     if (!context.mounted) return;
 
-    // Proceed with export
-    final result = await MessengerService.of(context).showLoading(
+    // Proceed with export. The archive is streamed directly from the original
+    // asset files on disk (one file at a time) so memory stays flat regardless
+    // of how many/large the assets are — see exportAssets crash fix.
+    final tarFile = await MessengerService.of(context).showLoading(
       debugSource: '$runtimeType#exportAssets',
       future: () async {
         final String exportFileName =
             "$kAppName-${kDeviceInfo.model}-assets-${DateTime.now().toIso8601String()}.tar.gz";
-        final tempDir = Directory(
-          '${SupportDirectoryPath.tmp.directoryPath}/assets_export_${DateTime.now().millisecondsSinceEpoch}',
-        );
 
-        await tempDir.create(recursive: true);
-
-        // Copy all downloaded assets to temp directory
-        for (final asset in _assets) {
-          final sourceFile = asset.localFile;
-          if (sourceFile != null && sourceFile.existsSync()) {
-            final destFile = File('${tempDir.path}/${asset.relativeLocalFilePath}');
-            await destFile.create(recursive: true);
-            await sourceFile.copy(destFile.path);
-          }
-        }
-
-        // Create tar.gz archive
         final tarFile = File("${SupportDirectoryPath.export_assets.directoryPath}/$exportFileName");
         await tarFile.create(recursive: true);
 
-        final entries = <TarEntry>[];
+        Stream<TarEntry> buildEntries() async* {
+          for (final asset in _assets) {
+            final file = asset.localFile;
+            if (file == null || !file.existsSync()) continue;
 
-        for (final entity in tempDir.listSync(recursive: true)) {
-          if (entity is File) {
-            final relativePath = entity.path.substring(tempDir.path.length + 1);
-            final bytes = await entity.readAsBytes();
-            entries.add(
-              TarEntry.data(
-                TarHeader(
-                  name: relativePath,
-                  mode: 420, // 0644 in octal
-                  size: bytes.length,
-                  modified: entity.lastModifiedSync(),
-                ),
-                bytes,
+            yield TarEntry(
+              TarHeader(
+                name: asset.relativeLocalFilePath, // eg. images/123.jpg
+                mode: 420, // 0644 in octal
+                size: file.lengthSync(),
+                modified: file.lastModifiedSync(),
               ),
+              file.openRead(), // lazy disk read — only one file streamed at a time
             );
           }
         }
 
-        await Stream.fromIterable(entries).transform(tarWriter).transform(gzip.encoder).pipe(tarFile.openWrite());
+        await buildEntries().transform(tarWriter).transform(gzip.encoder).pipe(tarFile.openWrite());
 
-        return (tarFile, tempDir);
+        return tarFile;
       },
     );
 
     if (!context.mounted) return;
-    if (result == null) return;
+    if (tarFile == null) return;
 
-    final tarFile = result.$1;
-    final tempDir = result.$2;
-
-    // Share/save the tar.gz file
-    if (Platform.isIOS) {
+    try {
+      // Share/save the tar.gz file by path (no in-memory copy of the archive).
+      // On Android the share sheet still offers "Save to Files/Drive".
       RenderBox? box = context.findRenderObject() as RenderBox?;
       await SharePlus.instance.share(
         ShareParams(
@@ -169,17 +185,29 @@ class ExportAssetsViewModel extends ChangeNotifier with DisposeAwareMixin {
           files: [XFile(tarFile.path)],
         ),
       );
-    } else if (Platform.isAndroid) {
-      await FilePicker.saveFile(
-        fileName: basename(tarFile.path),
-        type: FileType.custom,
-        allowedExtensions: ['gz'],
-        bytes: await tarFile.readAsBytes(),
-      );
+    } finally {
+      // Always clean up, even if sharing throws.
+      if (await tarFile.exists()) await tarFile.delete();
     }
 
-    // Cleanup
-    await tempDir.delete(recursive: true);
-    await tarFile.delete();
+    // Let the user know some assets couldn't be included in the export.
+    if (context.mounted && _skippedAssets.isNotEmpty) {
+      MessengerService.of(
+        context,
+      ).showSnackBar('${_skippedAssets.length} asset(s) were unavailable and skipped from the export.');
+    }
+  }
+
+  Future<void> _cleanUpStaleExports() async {
+    final exportDir = SupportDirectoryPath.export_assets.directory;
+    if (await exportDir.exists()) {
+      for (final entity in exportDir.listSync()) {
+        try {
+          await entity.delete(recursive: true);
+        } catch (_) {
+          // best-effort cleanup
+        }
+      }
+    }
   }
 }

--- a/lib/views/import_export/import_export_view_model.dart
+++ b/lib/views/import_export/import_export_view_model.dart
@@ -182,28 +182,27 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
         final tarFile = File("${SupportDirectoryPath.backups.directoryPath}/$exportFileName");
         await tarFile.create(recursive: true);
 
-        // Create tar.gz archive from directory
-        final entries = <TarEntry>[];
-
-        for (final entity in tempDir.listSync(recursive: true)) {
-          if (entity is File) {
-            final relativePath = entity.path.substring(tempDir.path.length + 1);
-            final bytes = await entity.readAsBytes();
-            entries.add(
-              TarEntry.data(
+        // Stream each file from the temp directory into the archive (one file
+        // at a time) instead of buffering them all in memory — avoids OOM
+        // crashes on large exports.
+        Stream<TarEntry> buildEntries() async* {
+          for (final entity in tempDir.listSync(recursive: true)) {
+            if (entity is File) {
+              final relativePath = entity.path.substring(tempDir.path.length + 1);
+              yield TarEntry(
                 TarHeader(
                   name: relativePath,
                   mode: 420, // 0644 in octal
-                  size: bytes.length,
+                  size: entity.lengthSync(),
                   modified: entity.lastModifiedSync(),
                 ),
-                bytes,
-              ),
-            );
+                entity.openRead(), // lazy disk read
+              );
+            }
           }
         }
 
-        await Stream.fromIterable(entries).transform(tarWriter).transform(gzip.encoder).pipe(tarFile.openWrite());
+        await buildEntries().transform(tarWriter).transform(gzip.encoder).pipe(tarFile.openWrite());
         return (tarFile, tempDir);
       },
     );
@@ -214,8 +213,9 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
     File tarFile = result.$1;
     Directory tempDir = result.$2;
 
-    // Share/save the tar.gz file
-    if (Platform.isIOS) {
+    try {
+      // Share/save the tar.gz file by path (no in-memory copy of the archive).
+      // On Android the share sheet still offers "Save to Files/Drive".
       RenderBox? box = context.findRenderObject() as RenderBox?;
       await SharePlus.instance.share(
         ShareParams(
@@ -224,18 +224,11 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
           files: [XFile(tarFile.path)],
         ),
       );
-    } else if (Platform.isAndroid) {
-      await FilePicker.saveFile(
-        fileName: basename(tarFile.path),
-        type: FileType.custom,
-        allowedExtensions: ['gz'],
-        bytes: await tarFile.readAsBytes(),
-      );
+    } finally {
+      // Always clean up, even if sharing throws.
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+      if (await tarFile.exists()) await tarFile.delete();
     }
-
-    // Cleanup
-    await tempDir.delete(recursive: true);
-    await tarFile.delete();
   }
 
   Future<void> exportText(BuildContext context) async {

--- a/lib/views/storage_management/storage_management_view_model.dart
+++ b/lib/views/storage_management/storage_management_view_model.dart
@@ -103,6 +103,9 @@ class StorageManagementViewModel extends ChangeNotifier {
 
     await storageInfoService.clearCachedNetworkImageCache();
 
+    // Also remove orphaned *.download temp files left by interrupted downloads.
+    await storageInfoService.clearOrphanedDownloads();
+
     await _loadLocalSizes();
     notifyListeners();
   }


### PR DESCRIPTION
- Stream files into tar.gz from disk instead of buffering all bytes in memory; share archive by path on Android (fixes export crash on large libraries)
- Skip per-asset download failures (e.g. 404) and continue, aborting only on auth errors; report skipped count
- Reset isDownloading in finally and stop the loop when the screen is popped (no more stuck "Downloading...")
- Atomic asset download (write to .download temp, then rename) to avoid truncated/corrupt files
- Clean up orphaned *.download temp files from Storage Management's clear cache action

Related Post:
https://www.reddit.com/r/StoryPad/comments/1ufkpsh/exporting_media_crashes/