### PR TITLE
Recover bare short Plus Codes using map camera center as reference

### DIFF
--- a/lib/core/services/geocoding/sp_coordinate_parser_service.dart
+++ b/lib/core/services/geocoding/sp_coordinate_parser_service.dart
@@ -10,6 +10,8 @@ import 'package:storypad/core/services/geocoding/sp_geocoding_service.dart';
 /// - Full Plus Code:  `7P28QRVW+62`  (decoded directly)
 /// - Short Plus Code:  `X4MQ+2V Al Haram, Egypt`  or  `X4HH+QX4, Egypt`
 ///   (space or comma-separated, location geocoded for reference, then recovered)
+/// - Bare Short Plus Code:  `GWCJ+6QH`  (no hint — recovered against
+///   [fallbackReference], e.g. the map's current camera center)
 ///
 /// Returns `null` when the input cannot be parsed or Plus Code recovery fails.
 class SpCoordinateParserService {
@@ -22,14 +24,20 @@ class SpCoordinateParserService {
   /// [referenceResolver] is called with the city/location hint when recovering
   /// a short Plus Code (e.g. "HVRG+727 Phnom Penh"). Defaults to the system
   /// geocoder. Inject a custom resolver in tests to avoid network calls.
+  ///
+  /// [fallbackReference] is the reference point used to recover a short Plus
+  /// Code when no location hint is supplied (e.g. a bare "GWCJ+6QH"), or when
+  /// the hint cannot be geocoded. Pass the map's current camera center so a
+  /// bare short code resolves to the area the user is looking at.
   static Future<SpLatLng?> parse(
     String input, {
     Future<SpLatLng?> Function(String hint)? referenceResolver,
+    SpLatLng? fallbackReference,
   }) async {
     final String text = input.trim();
     if (text.isEmpty) return null;
 
-    return _tryDecimal(text) ?? _tryCardinal(text) ?? await _tryPlusCode(text, referenceResolver);
+    return _tryDecimal(text) ?? _tryCardinal(text) ?? await _tryPlusCode(text, referenceResolver, fallbackReference);
   }
 
   // ---------------------------------------------------------------------------
@@ -83,7 +91,11 @@ class SpCoordinateParserService {
   // Plus Code  "7P28QRVW+62"  or  "X4MQ+2V Al Haram, Egypt"  or  "X4HH+QX4, Egypt"
   // ---------------------------------------------------------------------------
 
-  static Future<SpLatLng?> _tryPlusCode(String text, Future<SpLatLng?> Function(String hint)? referenceResolver) async {
+  static Future<SpLatLng?> _tryPlusCode(
+    String text,
+    Future<SpLatLng?> Function(String hint)? referenceResolver,
+    SpLatLng? fallbackReference,
+  ) async {
     // Split on the first space or comma to separate Plus Code from location hint.
     // Supported formats:
     //   - "7P28QRVW+62"                         (full Plus Code)
@@ -116,7 +128,7 @@ class SpCoordinateParserService {
 
       if (!code.isShort()) return null;
 
-      final SpLatLng? reference = await _resolveReference(locationHint, referenceResolver);
+      final SpLatLng? reference = await _resolveReference(locationHint, referenceResolver, fallbackReference);
       if (reference == null) return null;
 
       final olc.PlusCode full = code.recoverNearest(
@@ -129,15 +141,30 @@ class SpCoordinateParserService {
     }
   }
 
-  /// Geocode [locationHint] (e.g. "Phnom Penh") to get a reference point for
-  /// short Plus Code recovery. Returns `null` when geocoding is unavailable or
-  /// the query returns no results.
+  /// Resolves the reference point used to recover a short Plus Code.
+  ///
+  /// Prefers geocoding the [locationHint] (e.g. "Phnom Penh"); when no hint is
+  /// supplied or it cannot be geocoded, falls back to [fallbackReference] (e.g.
+  /// the map's current camera center). Returns `null` when neither is available.
   static Future<SpLatLng?> _resolveReference(
     String? locationHint,
     Future<SpLatLng?> Function(String hint)? referenceResolver,
+    SpLatLng? fallbackReference,
   ) async {
-    if (locationHint == null || locationHint.isEmpty) return null;
+    if (locationHint != null && locationHint.isNotEmpty) {
+      final SpLatLng? viaHint = await _geocodeHint(locationHint, referenceResolver);
+      if (viaHint != null) return viaHint;
+    }
 
+    return fallbackReference;
+  }
+
+  /// Geocode [locationHint] (e.g. "Phnom Penh") to a reference point. Returns
+  /// `null` when geocoding is unavailable or the query returns no results.
+  static Future<SpLatLng?> _geocodeHint(
+    String locationHint,
+    Future<SpLatLng?> Function(String hint)? referenceResolver,
+  ) async {
     if (referenceResolver != null) {
       return referenceResolver(locationHint);
     }

--- a/lib/views/map/manual_input/map_picker_manual_input_view.dart
+++ b/lib/views/map/manual_input/map_picker_manual_input_view.dart
@@ -15,7 +15,12 @@ import 'map_picker_manual_input_view_model.dart';
 part 'map_picker_manual_input_content.dart';
 
 class MapPickerManualInputRoute extends BaseRoute {
-  const MapPickerManualInputRoute();
+  const MapPickerManualInputRoute({this.referenceLatLng});
+
+  /// Reference point used to recover a bare short Plus Code (one typed without a
+  /// location hint, e.g. "GWCJ+6QH"). Pass the map's current camera center so
+  /// the code resolves to the area the user is looking at.
+  final SpLatLng? referenceLatLng;
 
   @override
   Widget buildPage(BuildContext context) => MapPickerManualInputView(params: this);

--- a/lib/views/map/manual_input/map_picker_manual_input_view_model.dart
+++ b/lib/views/map/manual_input/map_picker_manual_input_view_model.dart
@@ -55,7 +55,10 @@ class MapPickerManualInputViewModel extends ChangeNotifier with DisposeAwareMixi
     notifyListeners();
 
     try {
-      final SpLatLng? latLng = await SpCoordinateParserService.parse(text);
+      final SpLatLng? latLng = await SpCoordinateParserService.parse(
+        text,
+        fallbackReference: params.referenceLatLng,
+      );
       if (version != _resolveVersion || disposed) return;
 
       if (latLng == null) {

--- a/lib/views/map/picker/map_picker_content.dart
+++ b/lib/views/map/picker/map_picker_content.dart
@@ -160,7 +160,9 @@ class _MapPickerContent extends StatelessWidget {
           leadingIconData: SpIcons.locationPin,
           title: tr("button.manual_input"),
           onPressed: () async {
-            final place = await const MapPickerManualInputRoute().push(context);
+            final place = await MapPickerManualInputRoute(
+              referenceLatLng: viewModel.selectedPlace?.latLng ?? viewModel.initialSpMapCamera.target,
+            ).push(context);
             if (!context.mounted || place is! PlaceDbModel) return;
             unawaited(viewModel.selectSearchedPlace(place));
           },

--- a/test/core/services/geocoding/sp_coordinate_parser_service_test.dart
+++ b/test/core/services/geocoding/sp_coordinate_parser_service_test.dart
@@ -164,6 +164,52 @@ void main() {
       );
       expect(result, isNull);
     });
+
+    test('recovers bare short Plus Code (no hint) using fallbackReference', () async {
+      final String fullCode = olc.PlusCode.encode(phnomPenhOlc).toString();
+      final String shortCode = olc.PlusCode(fullCode).shorten(phnomPenhOlc).toString();
+
+      final result = await SpCoordinateParserService.parse(
+        shortCode,
+        fallbackReference: phnomPenhSp,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.latitude, closeTo(phnomPenhSp.latitude, 0.1));
+      expect(result.longitude, closeTo(phnomPenhSp.longitude, 0.1));
+    });
+
+    test('falls back to fallbackReference when the city hint cannot be geocoded', () async {
+      final String fullCode = olc.PlusCode.encode(phnomPenhOlc).toString();
+      final String shortCode = olc.PlusCode(fullCode).shorten(phnomPenhOlc).toString();
+
+      final result = await SpCoordinateParserService.parse(
+        '$shortCode Unknown City',
+        referenceResolver: (_) async => null,
+        fallbackReference: phnomPenhSp,
+      );
+
+      expect(result, isNotNull);
+      expect(result!.latitude, closeTo(phnomPenhSp.latitude, 0.1));
+      expect(result.longitude, closeTo(phnomPenhSp.longitude, 0.1));
+    });
+
+    test('prefers the city hint over fallbackReference when both resolve', () async {
+      // Short code generated relative to Phnom Penh; hint resolver returns
+      // Phnom Penh while the fallback points elsewhere. The hint must win.
+      final String fullCode = olc.PlusCode.encode(phnomPenhOlc).toString();
+      final String shortCode = olc.PlusCode(fullCode).shorten(phnomPenhOlc).toString();
+
+      final result = await SpCoordinateParserService.parse(
+        '$shortCode Phnom Penh',
+        referenceResolver: phnomPenhResolver,
+        fallbackReference: const SpLatLng(48.8566, 2.3522), // Paris — should be ignored
+      );
+
+      expect(result, isNotNull);
+      expect(result!.latitude, closeTo(phnomPenhSp.latitude, 0.1));
+      expect(result.longitude, closeTo(phnomPenhSp.longitude, 0.1));
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
A bare short Plus Code (e.g. "GWCJ+6QH") lacks its leading region characters and is ambiguous worldwide, so it could only resolve with a typed location hint. Add a fallbackReference to the parser and feed it the map picker's current camera center, so a hint-less short code resolves to the area the user is looking at.