### PR TITLE
Fix stale route-pop callbacks, JSON export no-op, and image cache timing

### DIFF
--- a/lib/core/services/assets/db_asset_loader_service.dart
+++ b/lib/core/services/assets/db_asset_loader_service.dart
@@ -23,7 +23,14 @@ class DbAssetLoaderService {
   final Map<String, Completer<File>> _inFlightByRelativePath = {};
   final Map<String, File> _resolvedByRelativePath = {};
 
-  File? getCachedFile(String relativePath) => _resolvedByRelativePath[relativePath];
+  File? getCachedFile(String relativePath) {
+    final cached = _resolvedByRelativePath[relativePath];
+    if (cached == null) return null;
+    if (cached.existsSync()) return cached;
+
+    _resolvedByRelativePath.remove(relativePath);
+    return null;
+  }
 
   /// Load a file by relative path.
   /// Returns cached result if exists and still valid; deduplicates concurrent requests for same path.

--- a/lib/core/services/assets/db_asset_loader_service.dart
+++ b/lib/core/services/assets/db_asset_loader_service.dart
@@ -23,6 +23,8 @@ class DbAssetLoaderService {
   final Map<String, Completer<File>> _inFlightByRelativePath = {};
   final Map<String, File> _resolvedByRelativePath = {};
 
+  File? getCachedFile(String relativePath) => _resolvedByRelativePath[relativePath];
+
   /// Load a file by relative path.
   /// Returns cached result if exists and still valid; deduplicates concurrent requests for same path.
   /// On errors, removes in-flight entry to allow retry.

--- a/lib/views/archives/archives_view_model.dart
+++ b/lib/views/archives/archives_view_model.dart
@@ -54,6 +54,6 @@ class ArchivesViewModel extends ChangeNotifier with DisposeAwareMixin {
       shouldPop = result == OkCancelResult.ok;
     }
 
-    if (shouldPop && context.mounted) Navigator.of(context).pop(result);
+    if (shouldPop && context.mounted && ModalRoute.of(context)?.isCurrent == true) Navigator.of(context).pop(result);
   }
 }

--- a/lib/views/import_export/import_export_view_model.dart
+++ b/lib/views/import_export/import_export_view_model.dart
@@ -290,8 +290,11 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
   Future<void> exportJson(BuildContext context) async {
     AnalyticsService.instance.logExportOfflineBackup();
 
-    DateTime? lastDbUpdatedAt = context.read<BackupProvider>().lastDbUpdatedAt;
-    if (lastDbUpdatedAt == null) return;
+    // lastDbUpdatedAt is only populated after a DB write or a cloud sync run this
+    // session, so it can legitimately still be null here (e.g. fresh session, no
+    // sync configured). It's only used as the backup's "created at" metadata, so
+    // falling back to now() is safe — don't reintroduce a null-guard early return.
+    DateTime lastDbUpdatedAt = context.read<BackupProvider>().lastDbUpdatedAt ?? DateTime.now();
 
     final String exportFileName = "$kAppName-${kDeviceInfo.model}-backup-${DateTime.now().toIso8601String()}.json";
 

--- a/lib/views/search/search_view_model.dart
+++ b/lib/views/search/search_view_model.dart
@@ -169,7 +169,7 @@ class SearchViewModel extends ChangeNotifier with DisposeAwareMixin, DebounchedC
       shouldPop = result == OkCancelResult.ok;
     }
 
-    if (shouldPop && context.mounted) Navigator.of(context).pop(result);
+    if (shouldPop && context.mounted && ModalRoute.of(context)?.isCurrent == true) Navigator.of(context).pop(result);
   }
 
   @override

--- a/lib/views/stories/edit/edit_story_view_model.dart
+++ b/lib/views/stories/edit/edit_story_view_model.dart
@@ -205,7 +205,7 @@ class EditStoryViewModel extends BaseStoryViewModel {
         if (userAction == OkCancelResult.ok) {
           await StoryDbModel.db.delete(story!.id, softDelete: false);
           story = null;
-          if (context.mounted) return Navigator.of(context).pop(null);
+          if (context.mounted && ModalRoute.of(context)?.isCurrent == true) return Navigator.of(context).pop(null);
         } else {
           return;
         }
@@ -218,7 +218,7 @@ class EditStoryViewModel extends BaseStoryViewModel {
         if (userAction == OkCancelResult.ok) {
           await StoryDbModel.db.set(initialStory!);
           story = initialStory;
-          if (context.mounted) return Navigator.of(context).pop(null);
+          if (context.mounted && ModalRoute.of(context)?.isCurrent == true) return Navigator.of(context).pop(null);
         }
       } else {
         if (context.mounted) Navigator.of(context).pop(null);

--- a/lib/views/tags/show/show_tag_view_model.dart
+++ b/lib/views/tags/show/show_tag_view_model.dart
@@ -101,6 +101,6 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
       shouldPop = result == OkCancelResult.ok;
     }
 
-    if (shouldPop && context.mounted) Navigator.of(context).pop(result);
+    if (shouldPop && context.mounted && ModalRoute.of(context)?.isCurrent == true) Navigator.of(context).pop(result);
   }
 }

--- a/lib/views/templates/edit/edit_template_view_model.dart
+++ b/lib/views/templates/edit/edit_template_view_model.dart
@@ -240,7 +240,7 @@ class EditTemplateViewModel extends ChangeNotifier with DisposeAwareMixin, Debou
         OkCancelResult userAction = await showDiscardConfirmation(context);
         if (userAction == OkCancelResult.ok) {
           await TemplateDbModel.db.delete(template.id, softDelete: false);
-          if (context.mounted) return Navigator.of(context).pop(null);
+          if (context.mounted && ModalRoute.of(context)?.isCurrent == true) return Navigator.of(context).pop(null);
         } else {
           return;
         }
@@ -253,7 +253,7 @@ class EditTemplateViewModel extends ChangeNotifier with DisposeAwareMixin, Debou
         if (userAction == OkCancelResult.ok) {
           await TemplateDbModel.db.set(params.initialTemplate!);
           template = params.initialTemplate!;
-          if (context.mounted) return Navigator.of(context).pop(null);
+          if (context.mounted && ModalRoute.of(context)?.isCurrent == true) return Navigator.of(context).pop(null);
         }
       } else {
         if (context.mounted) Navigator.of(context).pop(null);

--- a/lib/widgets/asset_db/sp_db_asset_loader.dart
+++ b/lib/widgets/asset_db/sp_db_asset_loader.dart
@@ -60,13 +60,13 @@ class _SpDbAssetLoaderState extends State<SpDbAssetLoader> {
   String get relativePath => widget.relativePath;
   List<BackupCloudService> get signedInServices => widget.signedInServices;
 
-  File? file;
+  late File? file = DbAssetLoaderService.instance.getCachedFile(widget.relativePath);
   Object? error;
 
   @override
   void initState() {
     super.initState();
-    load();
+    if (file == null) load();
   }
 
   Future<void> load() async {


### PR DESCRIPTION
## Summary
- Use cached image file before rendering, for better rendering during scroll
- Guard pop-with-result callbacks against stale route pops
- Fix JSON export silently no-op'ing on a fresh session