### PR TITLE
Add period reminder tile, auto re-auth on resume, and add-ons sheet UX

### DIFF
--- a/lib/core/services/auto_sync_trigger_service.dart
+++ b/lib/core/services/auto_sync_trigger_service.dart
@@ -9,7 +9,7 @@ import 'package:flutter/widgets.dart';
 class AutoSyncTriggerService with WidgetsBindingObserver {
   AutoSyncTriggerService({
     required this.onTrigger,
-    this.throttleDuration = const Duration(minutes: 30),
+    this.throttleDuration = const Duration(seconds: 5),
     DateTime Function()? now,
   }) : _now = now ?? DateTime.now;
 

--- a/lib/providers/app_lock_provider.dart
+++ b/lib/providers/app_lock_provider.dart
@@ -11,6 +11,7 @@ import 'package:storypad/core/storages/app_lock_storage.dart';
 import 'package:storypad/core/types/app_lock_question.dart';
 import 'package:storypad/views/app_locks/security_questions/security_questions_view.dart';
 import 'package:storypad/views/pin_unlock/pin_unlock_view.dart';
+import 'package:storypad/widgets/sp_app_lock_wrapper.dart';
 
 class AppLockProvider extends ChangeNotifier {
   AppLockProvider() {
@@ -117,12 +118,20 @@ class AppLockProvider extends ChangeNotifier {
   }
 
   Future<void> toggleBiometrics(BuildContext context) async {
-    bool authenticated = await localAuth.authenticate(title: tr('dialog.unlock_to_continue.title'));
+    // The native biometric prompt can itself trigger inactive/resumed lifecycle events, which
+    // would otherwise pop the app-lock barrier over this Settings screen while it's showing —
+    // same reasoning as disabling the lock around the camera/image picker.
+    await SpAppLockWrapper.disableAppLockIfHas(
+      context,
+      callback: () async {
+        bool authenticated = await localAuth.authenticate(title: tr('dialog.unlock_to_continue.title'));
 
-    if (authenticated) {
-      await storage.writeObject(appLock.copyWith(enabledBiometric: !(appLock.enabledBiometric == true)));
-      await reload();
-    }
+        if (authenticated) {
+          await storage.writeObject(appLock.copyWith(enabledBiometric: !(appLock.enabledBiometric == true)));
+          await reload();
+        }
+      },
+    );
   }
 
   Future<void> forgotPin(BuildContext context) async {

--- a/lib/views/add_ons/add_ons_content.dart
+++ b/lib/views/add_ons/add_ons_content.dart
@@ -31,47 +31,113 @@ class _AddOnTile extends StatelessWidget {
 
   final AddOnType addOn;
 
+  static List<String> _demoImagesFor(AddOnType addOn) {
+    switch (addOn) {
+      case .relax_sounds:
+        return SpDemoImagesSheet.relaxSoundDemoImages;
+      case .period_calendar:
+        return SpDemoImagesSheet.periodCalendarDemoImages;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    // Read-only: this tile rebuilds when AddOnsViewModel notifies (scoped to
+    // add-on changes via addListenerForAddOnChanges), not by watching
+    // DevicePreferencesProvider directly — see _RemindersContent for the same pattern.
     final provider = context.read<DevicePreferencesProvider>();
 
     bool enabled =
         (provider.enableRelaxSounds && addOn == AddOnType.relax_sounds) ||
         (provider.enablePeriodCalendar(context) && addOn == AddOnType.period_calendar);
 
+    // The switch reflects the true enabled state but doesn't toggle directly —
+    // tapping it (like tapping the tile) opens the sheet, where the real
+    // switch lives. Keeps this consistent with the reminders list tiles.
+    void openSheet() {
+      SpDemoImagesSheet(
+        demoImages: _demoImagesFor(addOn),
+        header: _AddOnSwitchTile(addOn: addOn),
+      ).show(context: context);
+    }
+
     return ListTile(
-      onTap: () {
-        switch (addOn) {
-          case .relax_sounds:
-            SpDemoImagesSheet.relaxSoundDemo().show(context: context);
-            break;
-          case .period_calendar:
-            SpDemoImagesSheet.periodCalendarDemo().show(context: context);
-            break;
-        }
-      },
+      onTap: openSheet,
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       leading: SpSettingIconBadge(
         weekday: addOn.weekdayColor,
         icon: addOn.icon,
       ),
-      title: Text.rich(
-        TextSpan(
-          text: addOn.displayName,
-          style: Theme.of(context).textTheme.bodyLarge,
-          children: [
-            if (addOn.designForFemale)
-              const WidgetSpan(
-                child: Icon(Icons.female_outlined, size: 22.0),
-                alignment: PlaceholderAlignment.middle,
-              ),
-          ],
-        ),
-      ),
+      title: _AddOnTitle(addOn: addOn),
       subtitle: Text(addOn.description),
-      trailing: Switch.adaptive(
-        value: enabled,
-        onChanged: (bool value) => provider.toggleAddOn(addOn, value),
+      trailing: Switch.adaptive(value: enabled, onChanged: (_) => openSheet()),
+    );
+  }
+}
+
+/// The sheet's [SpDemoImagesSheet.header]: the real switch that actually
+/// toggles the add-on. Tracks its own local state instead of watching
+/// [DevicePreferencesProvider] — toggleAddOn only fires its scoped 'add_on'
+/// listeners, not ChangeNotifier's notifyListeners(), so watching the
+/// provider here would never rebuild this switch (see reminders_content.dart
+/// for the same scoped-listener reasoning).
+class _AddOnSwitchTile extends StatefulWidget {
+  const _AddOnSwitchTile({required this.addOn});
+
+  final AddOnType addOn;
+
+  @override
+  State<_AddOnSwitchTile> createState() => _AddOnSwitchTileState();
+}
+
+class _AddOnSwitchTileState extends State<_AddOnSwitchTile> {
+  late bool _enabled;
+
+  @override
+  void initState() {
+    super.initState();
+    final provider = context.read<DevicePreferencesProvider>();
+    _enabled =
+        (provider.enableRelaxSounds && widget.addOn == AddOnType.relax_sounds) ||
+        (provider.enablePeriodCalendar(context) && widget.addOn == AddOnType.period_calendar);
+  }
+
+  void _setEnabled(bool value) {
+    context.read<DevicePreferencesProvider>().toggleAddOn(widget.addOn, value);
+    setState(() => _enabled = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile.adaptive(
+      contentPadding: const EdgeInsets.only(left: 16.0, right: 12.0),
+      value: _enabled,
+      secondary: SpSettingIconBadge(weekday: widget.addOn.weekdayColor, icon: widget.addOn.icon),
+      title: _AddOnTitle(addOn: widget.addOn),
+      subtitle: Text(widget.addOn.description),
+      onChanged: _setEnabled,
+    );
+  }
+}
+
+class _AddOnTitle extends StatelessWidget {
+  const _AddOnTitle({required this.addOn});
+
+  final AddOnType addOn;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text.rich(
+      TextSpan(
+        text: addOn.displayName,
+        style: Theme.of(context).textTheme.bodyLarge,
+        children: [
+          if (addOn.designForFemale)
+            const WidgetSpan(
+              child: Icon(Icons.female_outlined, size: 22.0),
+              alignment: PlaceholderAlignment.middle,
+            ),
+        ],
       ),
     );
   }

--- a/lib/views/calendar/period/period_calendar_content.dart
+++ b/lib/views/calendar/period/period_calendar_content.dart
@@ -61,7 +61,14 @@ class _PeriodCalendarContent extends StatelessWidget {
                 child: buildCalendar(context, showBottomBorder: false, scrollable: true),
               ),
             ),
-            Flexible(child: buildStoryList(context)),
+            Flexible(
+              child: Stack(
+                children: [
+                  buildStoryList(context),
+                  buildReminderTile(context),
+                ],
+              ),
+            ),
           ],
         ),
       ),
@@ -81,7 +88,54 @@ class _PeriodCalendarContent extends StatelessWidget {
           ),
         ];
       },
-      body: buildStoryList(context),
+      body: Stack(
+        children: [
+          buildStoryList(context),
+          buildReminderTile(context),
+        ],
+      ),
+    );
+  }
+
+  /// Compact entry point to the built-in period reminder — full editing
+  /// (time, enable/disable) happens in [SpEditReminderSheet], same as the
+  /// reminders page. Scoped to `periodReminder` via `context.select` so this
+  /// tile only rebuilds when that specific reminder changes.
+  Widget buildReminderTile(BuildContext context) {
+    final reminder = context.select((DevicePreferencesProvider provider) => provider.periodReminder);
+    final enabled = reminder?.enabled ?? false;
+
+    void openSheet() =>
+        SpEditReminderSheet(reminder: reminder ?? ReminderObject.builtin(ReminderType.period)).show(context: context);
+
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            Theme.of(context).scaffoldBackgroundColor,
+            Theme.of(context).scaffoldBackgroundColor.withValues(alpha: 0.0),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+      ),
+      child: ListTile(
+        tileColor: Colors.transparent,
+        leading: const Icon(SpIcons.alarm),
+        title: Text(ReminderType.period.title),
+        subtitle: Text(
+          enabled && reminder != null
+              ? tr(
+                  'reminder.summary.around_time',
+                  namedArgs: {'S_TIME': MaterialLocalizations.of(context).formatTimeOfDay(reminder.timeOfDay)},
+                )
+              : ReminderType.period.description,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+        trailing: Switch.adaptive(value: enabled, onChanged: (_) => openSheet()),
+        onTap: openSheet,
+      ),
     );
   }
 
@@ -120,10 +174,14 @@ class _PeriodCalendarContent extends StatelessWidget {
     }
   }
 
+  // Matches the two-line ListTile in buildReminderTile — the story list needs
+  // this much top padding so its content clears the tile floating over it.
+  static const double _reminderTileHeight = 72.0;
+
   Widget buildStoryList(BuildContext context) {
     if (viewModel.selectedEventStories?.items == null || viewModel.selectedEventStories?.items.isEmpty == true) {
       return Padding(
-        padding: const EdgeInsets.all(16.0),
+        padding: const EdgeInsets.all(16.0).copyWith(top: 16.0 + _reminderTileHeight),
         child: Text(
           tr('general.no_story_yet'),
           style: Theme.of(context).textTheme.bodyMedium,
@@ -132,10 +190,13 @@ class _PeriodCalendarContent extends StatelessWidget {
       );
     }
 
-    return SpStoryList(
-      stories: viewModel.selectedEventStories,
-      onChanged: (item) => viewModel.load(initialSelectedDate: viewModel.selectedEventDate),
-      onDeleted: () => viewModel.load(initialSelectedDate: viewModel.selectedEventDate),
+    return Padding(
+      padding: const EdgeInsets.only(top: _reminderTileHeight),
+      child: SpStoryList(
+        stories: viewModel.selectedEventStories,
+        onChanged: (item) => viewModel.load(initialSelectedDate: viewModel.selectedEventDate),
+        onDeleted: () => viewModel.load(initialSelectedDate: viewModel.selectedEventDate),
+      ),
     );
   }
 }

--- a/lib/views/calendar/period/period_calendar_view.dart
+++ b/lib/views/calendar/period/period_calendar_view.dart
@@ -1,7 +1,10 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:storypad/core/objects/reminder_object.dart';
+import 'package:storypad/core/types/reminder_type.dart';
 import 'package:storypad/providers/device_preferences_provider.dart';
+import 'package:storypad/widgets/bottom_sheets/sp_edit_reminder_sheet.dart';
 import 'package:storypad/widgets/calendar/sp_calendar.dart';
 import 'package:storypad/widgets/calendar/sp_calendar_period_date_cell.dart';
 import 'package:storypad/widgets/sp_fab_location.dart';

--- a/lib/widgets/bottom_sheets/sp_demo_images_sheet.dart
+++ b/lib/widgets/bottom_sheets/sp_demo_images_sheet.dart
@@ -3,10 +3,17 @@ import 'package:storypad/core/services/cloud_storage/cloud_storage_service.dart'
 import 'package:storypad/widgets/bottom_sheets/base_bottom_sheet.dart';
 import 'package:storypad/widgets/sp_demo_images.dart';
 
+/// Generic "preview a feature" sheet: an optional [header] (e.g. an enable
+/// switch) above a horizontal carousel of demo screenshots. Callers own what
+/// the header looks like and what it toggles — this sheet only lays it out.
 class SpDemoImagesSheet extends BaseBottomSheet {
   const SpDemoImagesSheet({
     required this.demoImages,
+    this.header,
   });
+
+  final List<String> demoImages;
+  final Widget? header;
 
   static const List<String> periodCalendarDemoImages = [
     "/feature_demos/period_calendar/period_calendar_1__1080x2400.jpg",
@@ -33,25 +40,19 @@ class SpDemoImagesSheet extends BaseBottomSheet {
     }
   }
 
-  final List<String> demoImages;
   @override
   bool get fullScreen => false;
-
-  double get height => 380.0;
-
-  factory SpDemoImagesSheet.periodCalendarDemo() {
-    return const SpDemoImagesSheet(demoImages: periodCalendarDemoImages);
-  }
-
-  factory SpDemoImagesSheet.relaxSoundDemo() {
-    return const SpDemoImagesSheet(demoImages: relaxSoundDemoImages);
-  }
 
   @override
   Widget build(BuildContext context, double bottomPadding) {
     return Column(
       mainAxisSize: .min,
       children: [
+        if (header case final header?) ...[
+          const SizedBox(height: 8),
+          header,
+          const SizedBox(height: 8),
+        ],
         SpDemoImages(
           demoImageUrlPaths: demoImages,
           skeletonCount: demoImages.length,

--- a/lib/widgets/side_items/local_widgets/backup_tile.dart
+++ b/lib/widgets/side_items/local_widgets/backup_tile.dart
@@ -5,7 +5,6 @@ import 'package:provider/provider.dart';
 import 'package:storypad/core/extensions/color_scheme_extension.dart';
 import 'package:storypad/core/helpers/date_format_helper.dart';
 import 'package:storypad/core/services/backups/backup_cloud_service.dart';
-import 'package:storypad/core/services/backups/sync_steps/sync_step.dart';
 import 'package:storypad/core/types/backup_connection_status.dart';
 import 'package:storypad/providers/backup_provider.dart';
 import 'package:storypad/providers/backup_sync_state_store.dart';
@@ -133,8 +132,8 @@ class BackupTile extends StatelessWidget {
       subtitle = Text(tr("general.syncing"));
       action = null;
 
-      final currentStep = _currentActiveStep(provider);
-      if (currentStep != null) subtitle = Text("${tr("general.syncing")} ${currentStep.stepNumber}/4");
+      final progress = _overallSyncProgress(provider);
+      if (progress != null) subtitle = Text("${tr("general.syncing")} ${progress.current}/${progress.total}");
 
       title = Text.rich(
         TextSpan(
@@ -239,12 +238,22 @@ class BackupTile extends StatelessWidget {
     return _firstSignedInService(provider) ?? provider.services.first;
   }
 
-  /// The step of whichever service is currently mid-sync — sync runs are
-  /// sequential, so at most one service is ever [SyncActivity.active].
-  SyncStep? _currentActiveStep(BackupProvider provider) {
-    for (final service in provider.services) {
-      final status = provider.statusFor(service.serviceType);
-      if (status.activity == SyncActivity.active) return status.currentStep;
+  /// Combines every signed-in service's 4 steps into one running count, so
+  /// syncing e.g. 2 services shows 1/8..8/8 instead of restarting at 1/4 for
+  /// each service in turn. Sync runs sequentially through provider.services
+  /// (see BackupProvider._syncBackupAcrossDevices), so a signed-in service
+  /// earlier in that order than the currently active one has already
+  /// completed all 4 of its own steps.
+  ({int current, int total})? _overallSyncProgress(BackupProvider provider) {
+    final signedIn = provider.services.where((service) => service.isSignedIn).toList();
+    if (signedIn.isEmpty) return null;
+
+    for (var i = 0; i < signedIn.length; i++) {
+      final status = provider.statusFor(signedIn[i].serviceType);
+      final step = status.currentStep;
+      if (status.activity == SyncActivity.active && step != null) {
+        return (current: i * 4 + step.stepNumber, total: signedIn.length * 4);
+      }
     }
     return null;
   }

--- a/lib/widgets/sp_app_lock_wrapper.dart
+++ b/lib/widgets/sp_app_lock_wrapper.dart
@@ -64,6 +64,12 @@ class _LockedBarrierState extends State<_LockedBarrier> with SingleTickerProvide
   bool barrierShown = true;
   bool listenToLifeCycle = true;
 
+  // Set only when we actually reach `paused` (a real backgrounding), and consumed the next
+  // time we reach `resumed`. This is what tells resume to re-authenticate automatically —
+  // relying on `isCurrent` for that instead caused a loop, because presenting the native
+  // biometric prompt itself fires `inactive`/`resumed` without ever pausing the app.
+  bool _needsReAuthOnResume = false;
+
   Timer? _reEnableLifeCycleTimer;
 
   Future<T> disableAppLockIfHas<T>(
@@ -126,6 +132,7 @@ class _LockedBarrierState extends State<_LockedBarrier> with SingleTickerProvide
       case AppLifecycleState.paused:
         if (listenToLifeCycle) {
           authenticated = false;
+          _needsReAuthOnResume = true;
           showBarrierInstantly();
         }
         break;
@@ -134,10 +141,12 @@ class _LockedBarrierState extends State<_LockedBarrier> with SingleTickerProvide
           // Only a transient `inactive` happened (e.g. control centre, share sheet) and we
           // never actually reached `paused`, so no re-auth is needed — just reveal again.
           revealBarrier();
-        } else if (listenToLifeCycle && ModalRoute.of(context) != null && ModalRoute.of(context)?.isCurrent == false) {
-          // There are cases when the user has already canceled authentication, but the app resumes and may call authenticate() again.
-          // This check ensures we only re-authenticate when this route is not the current one, avoiding potential authentication loops.
-          authenticate();
+        } else if (listenToLifeCycle && _needsReAuthOnResume) {
+          _needsReAuthOnResume = false;
+          // Belt-and-suspenders: skip if an authentication attempt is already in flight
+          // (e.g. the native biometric prompt itself caused a real pause/resume on some
+          // platform), so we never fire a second concurrent prompt.
+          if (!context.read<AppLockProvider>().avoidDublciated.isRunning) authenticate();
         }
         break;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.33.0+805
+version: 2.33.0+808
 publish_to: none
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
> Just added small UX improvements I found while using.

## Summary
- Surface the built-in period reminder as a fading tile over the period calendar's story list, opening the same compact edit sheet used on the reminders page
- Fix resume auth: track real backgrounding (paused) instead of relying on the barrier route's isCurrent check, so biometrics auto-prompt on genuine app resume
- Make the add-ons list tile's switch open SpDemoImagesSheet instead of toggling directly, matching the reminders UX; generalize the sheet to take demoImages + an optional header instead of an AddOnType