### PR TITLE
Proxy MapTiler tile requests through static.storypad.me

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -16,7 +16,7 @@ const String kRevenueCatIosApiKey = String.fromEnvironment('REVENUE_CAT_IOS_API_
 const String kEmailHasherSecreyKey = String.fromEnvironment('EMAIL_HASHER_SECRET_KEY');
 const String kGoogleMapsAndroidApiKey = String.fromEnvironment('GOOGLE_MAPS_ANDROID_API_KEY');
 const String kGoogleMapsIosApiKey = String.fromEnvironment('GOOGLE_MAPS_IOS_API_KEY');
-const String kMapTilerApiKey = String.fromEnvironment('MAPTILER_API_KEY');
+const String kMapTileProxySecret = String.fromEnvironment('MAP_TILE_PROXY_SECRET');
 
 const bool kIsCupertino = String.fromEnvironment('CUPERTINO') == 'yes';
 

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -18,6 +18,10 @@ const String kGoogleMapsAndroidApiKey = String.fromEnvironment('GOOGLE_MAPS_ANDR
 const String kGoogleMapsIosApiKey = String.fromEnvironment('GOOGLE_MAPS_IOS_API_KEY');
 const String kMapTileProxySecret = String.fromEnvironment('MAP_TILE_PROXY_SECRET');
 
+/// Base URL for static.storypad.me — serves remote config, cloud-stored assets,
+/// and the MapTiler tile proxy. Override via `--dart-define=CDN_BASE_URL=https://...`.
+const String kCdnBaseUrl = String.fromEnvironment('CDN_BASE_URL', defaultValue: 'https://static.storypad.me');
+
 const bool kIsCupertino = String.fromEnvironment('CUPERTINO') == 'yes';
 
 const Color kDefaultColorSeed = Colors.black;

--- a/lib/core/services/cloud_storage/adaptors/base_cloud_storage_adaptor.dart
+++ b/lib/core/services/cloud_storage/adaptors/base_cloud_storage_adaptor.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/services/cloud_storage/adaptors/cdn_cloud_storage_adaptor.dart';
 
 /// Thrown when download is rejected due to access denial.
@@ -10,9 +11,7 @@ class CloudStorageUnauthorizedException implements Exception {
 
 abstract class BaseCloudStorageAdaptor {
   static BaseCloudStorageAdaptor create() {
-    // CDN base URL can be overridden via --dart-define=CDN_BASE_URL=https://...
-    const cdnBaseUrl = String.fromEnvironment('CDN_BASE_URL', defaultValue: 'https://static.storypad.me');
-    return CdnCloudStorageAdaptor(baseUrl: cdnBaseUrl);
+    return CdnCloudStorageAdaptor(baseUrl: kCdnBaseUrl);
   }
 
   /// Download the raw bytes for [hashPath] (e.g. `/relax_sounds/animal/forest_birds-abc123.svg`).

--- a/lib/core/services/geocoding/maptiler/sp_maptiler_geocoding_service.dart
+++ b/lib/core/services/geocoding/maptiler/sp_maptiler_geocoding_service.dart
@@ -2,8 +2,6 @@ import 'dart:convert';
 
 // ignore: depend_on_referenced_packages
 import 'package:http/http.dart' as http;
-
-import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/databases/models/place_db_model.dart';
 import 'package:storypad/core/objects/sp_latlng.dart';
 import 'package:storypad/core/services/geocoding/sp_geocoding_service.dart';
@@ -15,6 +13,8 @@ import 'package:storypad/core/services/logger/app_logger.dart';
 /// API documentation: https://docs.maptiler.com/cloud/api/geocoding/
 class SpMapTilerGeocodingService implements SpGeocodingService {
   static const String _baseUrl = 'https://api.maptiler.com/geocoding';
+
+  static const String kMapTilerApiKey = '';
 
   @override
   Future<PlaceDbModel?> reverseGeocode(SpLatLng latLng) async {

--- a/lib/core/services/geocoding/sp_geocoding_service.dart
+++ b/lib/core/services/geocoding/sp_geocoding_service.dart
@@ -5,7 +5,6 @@ import 'package:storypad/core/databases/models/place_db_model.dart';
 import 'package:storypad/core/databases/models/story_db_model.dart';
 import 'package:storypad/core/objects/sp_latlng.dart';
 import 'package:storypad/core/objects/sp_latlng_bounds.dart';
-import 'package:storypad/core/services/geocoding/maptiler/sp_maptiler_geocoding_service.dart';
 import 'package:storypad/core/services/geocoding/sp_null_geocoding_service.dart';
 import 'package:storypad/core/services/geocoding/system/sp_system_geocoding_service.dart';
 
@@ -32,7 +31,7 @@ abstract class SpGeocodingService {
       ? SpSystemGeocodingService()
       : const SpNullGeocodingService();
 
-  static final onlineInstance = SpMapTilerGeocodingService();
+  static const onlineInstance = SpNullGeocodingService();
 
   /// Convert coordinates to a human-readable place.
   ///

--- a/lib/core/services/geocoding/sp_null_geocoding_service.dart
+++ b/lib/core/services/geocoding/sp_null_geocoding_service.dart
@@ -14,5 +14,9 @@ class SpNullGeocodingService implements SpGeocodingService {
   Future<PlaceDbModel?> reverseGeocode(SpLatLng latLng) async => null;
 
   @override
-  Future<List<PlaceDbModel>> searchPlaces(String query, {SpLatLng? proximity}) async => [];
+  Future<List<PlaceDbModel>> searchPlaces(
+    String query, {
+    SpLatLng? proximity,
+    List<String> countries = const [],
+  }) async => [];
 }

--- a/lib/core/services/remote_config/adaptors/http_remote_config_adaptor.dart
+++ b/lib/core/services/remote_config/adaptors/http_remote_config_adaptor.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 // ignore: depend_on_referenced_packages
 import 'package:http/http.dart' as http;
+import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/services/remote_config/adaptors/base_remote_config_adaptor.dart';
 import 'package:storypad/core/storages/base_object_storages/map_storage.dart';
 
@@ -22,7 +23,7 @@ class HttpRemoteConfigAdaptor extends BaseRemoteConfigAdaptor {
   final RemoteConfigCacheStorage _cache;
 
   HttpRemoteConfigAdaptor({
-    this.baseUrl = 'https://static.storypad.me',
+    this.baseUrl = kCdnBaseUrl,
     http.Client? httpClient,
     RemoteConfigCacheStorage? cache,
   }) : _httpClient = httpClient ?? http.Client(),

--- a/lib/views/map/map_content.dart
+++ b/lib/views/map/map_content.dart
@@ -14,54 +14,44 @@ class _MapContent extends StatelessWidget {
         leading: BackButton(
           onPressed: () => Navigator.of(context).pop(),
         ),
+        actions: [
+          IconButton(
+            tooltip: tr("button.switch_map_style"),
+            icon: SpAnimatedIcons.fadeScale(
+              duration: Durations.long1,
+              firstChild: const Icon(SpIcons.map),
+              secondChild: const Icon(SpIcons.satellite),
+              showFirst: viewModel.mapStyle == SpMapStyle.streets,
+            ),
+            onPressed: () => viewModel.setMapStyle(viewModel.mapStyle == .streets ? .satellite : .streets),
+          ),
+          SpSingleStateWidget.listen(
+            initialValue: false,
+            builder: (context, loading, notifier) {
+              return IconButton(
+                tooltip: tr("button.move_to_current_location"),
+                icon: loading
+                    ? const SizedBox.square(
+                        dimension: 24.0,
+                        child: CircularProgressIndicator.adaptive(),
+                      )
+                    : const Icon(SpIcons.myLocation),
+                onPressed: () async {
+                  notifier.value = true;
+                  await viewModel.goToCurrentLocation(context);
+                  notifier.value = false;
+                },
+              );
+            },
+          ),
+          const SizedBox(width: 4.0),
+        ],
       ),
       floatingActionButtonLocation: SpFabLocation.endFloat(context),
-      floatingActionButton: Column(
-        mainAxisSize: .min,
-        crossAxisAlignment: .end,
-        children: [
-          Container(
-            margin: const EdgeInsets.only(right: 4.0),
-            child: IconButton(
-              tooltip: tr("button.switch_map_style"),
-              icon: SpAnimatedIcons.fadeScale(
-                duration: Durations.long1,
-                firstChild: const Icon(SpIcons.map),
-                secondChild: const Icon(SpIcons.satellite),
-                showFirst: viewModel.mapStyle == SpMapStyle.streets,
-              ),
-              onPressed: () => viewModel.setMapStyle(viewModel.mapStyle == .streets ? .satellite : .streets),
-            ),
-          ),
-          Container(
-            margin: const EdgeInsets.only(right: 4.0),
-            child: SpSingleStateWidget.listen(
-              initialValue: false,
-              builder: (context, loading, notifier) {
-                return IconButton(
-                  tooltip: tr("button.move_to_current_location"),
-                  icon: loading
-                      ? const SizedBox.square(
-                          dimension: 24.0,
-                          child: CircularProgressIndicator.adaptive(),
-                        )
-                      : const Icon(SpIcons.myLocation),
-                  onPressed: () async {
-                    notifier.value = true;
-                    await viewModel.goToCurrentLocation(context);
-                    notifier.value = false;
-                  },
-                );
-              },
-            ),
-          ),
-          const SizedBox(height: 4.0),
-          FloatingActionButton(
-            tooltip: tr("button.new_story"),
-            child: const Icon(SpIcons.newStory),
-            onPressed: () => viewModel.goToNewPage(),
-          ),
-        ],
+      floatingActionButton: FloatingActionButton(
+        tooltip: tr("button.new_story"),
+        child: const Icon(SpIcons.newStory),
+        onPressed: () => viewModel.goToNewPage(),
       ),
       body: _buildMapLayer(context),
     );

--- a/lib/views/settings/local_widgets/map_provider_tile.dart
+++ b/lib/views/settings/local_widgets/map_provider_tile.dart
@@ -1,4 +1,5 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:storypad/core/constants/app_constants.dart';
@@ -31,7 +32,8 @@ class MapProviderTile extends StatelessWidget {
         // Shown where Google Maps can't load — but also to anyone who has
         // already switched, wherever they are now. Hiding it the moment they
         // travel out of the region would be a one-way door.
-        final bool visible = SpMapRenderer.selectable(kLocalTimezone) || provider.preferences.mapRenderer != null;
+        final bool visible =
+            SpMapRenderer.selectable(kLocalTimezone) || provider.preferences.mapRenderer != null || kDebugMode;
         if (!visible) return const SizedBox.shrink();
 
         return MapProviderTile(

--- a/lib/widgets/maps/map_types.dart
+++ b/lib/widgets/maps/map_types.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/widgets.dart';
+import 'package:storypad/core/constants/app_constants.dart';
 import 'package:storypad/core/objects/sp_latlng_bounds.dart';
 import 'package:storypad/core/objects/sp_latlng.dart';
 
@@ -99,9 +100,9 @@ extension SpMapStyleExtension on SpMapStyle {
   String get mapTilerUrlTemplate {
     switch (this) {
       case SpMapStyle.streets:
-        return 'https://static.storypad.me/maptiler/streets/{z}/{x}/{y}.png';
+        return '$kCdnBaseUrl/maptiler/streets/{z}/{x}/{y}.png';
       case SpMapStyle.satellite:
-        return 'https://static.storypad.me/maptiler/hybrid-v4/{z}/{x}/{y}.png';
+        return '$kCdnBaseUrl/maptiler/hybrid-v4/{z}/{x}/{y}.png';
     }
   }
 }

--- a/lib/widgets/maps/map_types.dart
+++ b/lib/widgets/maps/map_types.dart
@@ -99,9 +99,9 @@ extension SpMapStyleExtension on SpMapStyle {
   String get mapTilerUrlTemplate {
     switch (this) {
       case SpMapStyle.streets:
-        return 'https://api.maptiler.com/maps/streets/{z}/{x}/{y}.png?key=cWUdEifZoUYEaZRNo6nt';
+        return 'https://static.storypad.me/maptiler/streets/{z}/{x}/{y}.png';
       case SpMapStyle.satellite:
-        return 'https://api.maptiler.com/maps/hybrid-v4/{z}/{x}/{y}.png?key=cWUdEifZoUYEaZRNo6nt';
+        return 'https://static.storypad.me/maptiler/hybrid-v4/{z}/{x}/{y}.png';
     }
   }
 }

--- a/lib/widgets/maps/sp_flutter_map.dart
+++ b/lib/widgets/maps/sp_flutter_map.dart
@@ -162,6 +162,9 @@ class _SpFlutterMapState<T> extends State<SpFlutterMap<T>> with DebounchedCallba
         TileLayer(
           urlTemplate: widget.mapStyle.mapTilerUrlTemplate,
           userAgentPackageName: kPackageInfo.packageName,
+          tileProvider: NetworkTileProvider(
+            headers: {'X-Map-Proxy-Secret': kMapTileProxySecret},
+          ),
         ),
         if (_currentLocation != null)
           CircleLayer(


### PR DESCRIPTION
## Summary

- Map tile URLs (`SpMapStyle.mapTilerUrlTemplate`) now point at `static.storypad.me/maptiler/<style>/<z>/<x>/<y>.png` instead of embedding the MapTiler API key directly — the key was previously a plaintext literal in `map_types.dart`. A Cloudflare Worker on `static.storypad.me` proxies these requests to MapTiler with the real key held server-side (style/coordinate whitelist, a shared-secret header, per-IP rate limit, edge caching). Worker change: theachoem/storypad_cdn#1
- The app authenticates to the proxy via a new `kMapTileProxySecret` dart-define, sent as the `X-Map-Proxy-Secret` header through a custom `NetworkTileProvider` on the `flutter_map` `TileLayer`.
- Disables MapTiler-backed online geocoding (`SpGeocodingService.onlineInstance` now uses `SpNullGeocodingService`) since that path had the same key-exposure issue and wasn't in scope for the proxy yet.
- Minor map view tweaks: AppBar/FAB layout in `map_content.dart`, and the map provider setting is now also visible in debug builds (`map_provider_tile.dart`).

## Flow

```mermaid
sequenceDiagram
    participant App as StoryPad app
    participant Worker as static.storypad.me Worker
    participant MapTiler

    App->>Worker: GET /maptiler/streets/{z}/{x}/{y}.png<br/>X-Map-Proxy-Secret: shared secret
    Worker->>Worker: validate style/coords, check secret,<br/>rate limit, check edge cache
    Worker->>MapTiler: GET /maps/streets/{z}/{x}/{y}.png?key=real key
    MapTiler-->>Worker: tile PNG
    Worker-->>App: tile PNG (cached at edge)
```

## Test plan

- [x] `dart analyze` clean
- [x] `bin/format` clean
- [x] Verified the deployed worker directly with curl (auth required, style/coordinate validation, caching)
- [ ] Manual: run the app, switch to the flutter_map provider (Settings → Region → Map Provider), confirm Streets and Satellite tiles render