### PR TITLE
Add Dropbox as a backup/sync provider

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -103,6 +103,10 @@ android {
             applicationId = "com.juniorise.spooky"
             namespace = "com.juniorise.spooky"
             manifestPlaceholders["appLogo"] = "ic_launcher"
+            // Dropbox OAuth2 redirect scheme — must match DropboxOAuthService's
+            // per-flavor scheme constant and the redirect URI registered in the
+            // Dropbox app console.
+            manifestPlaceholders["dropboxCallbackScheme"] = "spooky"
         }
 
         create("storypad") {
@@ -110,6 +114,7 @@ android {
             applicationId = "com.tc.writestory"
             namespace = "com.tc.writestory"
             manifestPlaceholders["appLogo"] = "storypad_logo_1_0"
+            manifestPlaceholders["dropboxCallbackScheme"] = "storypad"
         }
 
         create("community") {
@@ -117,6 +122,7 @@ android {
             applicationId = "com.juniorise.spooky.community"
             namespace = "com.juniorise.spooky.community"
             manifestPlaceholders["appLogo"] = "ic_launcher"
+            manifestPlaceholders["dropboxCallbackScheme"] = "spookycommunity"
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,6 +55,26 @@
             </intent-filter>
         </activity>
 
+        <!-- https://pub.dev/packages/flutter_web_auth_2 — receives the Dropbox
+             OAuth2 redirect back into the app after the system browser / Custom
+             Tab hand-off. Scheme is a per-flavor Gradle manifest placeholder
+             (build.gradle.kts productFlavors) matching DropboxOAuthService's
+             scheme constant and the redirect URI registered in the Dropbox
+             app console — plain deep link, no hosted redirect domain needed
+             (PKCE already defeats a code-interception attack, which is the
+             only thing a hosted/Universal-Link redirect would add). -->
+        <activity
+            android:name="com.linusu.flutter_web_auth_2.CallbackActivity"
+            android:exported="true"
+            android:taskAffinity="">
+            <intent-filter android:label="flutter_web_auth_2">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="${dropboxCallbackScheme}" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -18,6 +18,10 @@ const String kGoogleMapsAndroidApiKey = String.fromEnvironment('GOOGLE_MAPS_ANDR
 const String kGoogleMapsIosApiKey = String.fromEnvironment('GOOGLE_MAPS_IOS_API_KEY');
 const String kMapTileProxySecret = String.fromEnvironment('MAP_TILE_PROXY_SECRET');
 
+/// Dropbox OAuth2 "App key" (client ID) — not a secret (Dropbox's PKCE flow
+/// for public/native clients needs no client secret).
+const String kDropboxAppKey = String.fromEnvironment('DROPBOX_APP_KEY');
+
 /// Base URL for static.storypad.me — serves remote config, cloud-stored assets,
 /// and the MapTiler tile proxy.
 const String kCdnBaseUrl = String.fromEnvironment('CDN_BASE_URL', defaultValue: 'https://static.storypad.me');

--- a/lib/core/databases/adapters/objectbox/preferences_box.dart
+++ b/lib/core/databases/adapters/objectbox/preferences_box.dart
@@ -14,11 +14,12 @@ class PreferencesBox extends BaseBox<PreferenceObjectBox, PreferenceDbModel> {
   _DefinedPreference<String> storageQuotaFor(BackupServiceType serviceType) {
     return switch (serviceType) {
       BackupServiceType.google_drive => _DefinedPreference<String>(id: 3, key: 'storage_quota_google_drive'),
-      BackupServiceType.nextcloud => _DefinedPreference<String>(id: 5, key: 'storage_quota_nextcloud'),
       // iCloud has no per-app storage quota API (ICloudCloudService.fetchStorageQuota
       // always returns null), but a defined preference is still needed so this
       // switch stays exhaustive.
       BackupServiceType.icloud => _DefinedPreference<String>(id: 7, key: 'storage_quota_icloud'),
+      BackupServiceType.dropbox => _DefinedPreference<String>(id: 9, key: 'storage_quota_dropbox'),
+      BackupServiceType.nextcloud => _DefinedPreference<String>(id: 5, key: 'storage_quota_nextcloud'),
     };
   }
 
@@ -35,6 +36,10 @@ class PreferencesBox extends BaseBox<PreferenceObjectBox, PreferenceDbModel> {
       BackupServiceType.icloud => _DefinedPreference<DateTime>(
         id: 8,
         key: 'storage_quota_fetched_at_icloud',
+      ),
+      BackupServiceType.dropbox => _DefinedPreference<DateTime>(
+        id: 10,
+        key: 'storage_quota_fetched_at_dropbox',
       ),
     };
   }

--- a/lib/core/objects/cloud_file_object.dart
+++ b/lib/core/objects/cloud_file_object.dart
@@ -77,6 +77,25 @@ class CloudFileObject {
     );
   }
 
+  /// [file] is the decoded JSON metadata object Dropbox returns from
+  /// `files/upload`, `files/get_metadata`, `files/list_folder`, etc. Unlike
+  /// Nextcloud/iCloud, Dropbox assigns a real stable file ID (`id:xxxx`)
+  /// independent of path — that ID is used as [id] here, not the path.
+  factory CloudFileObject.fromDropbox(Map<String, dynamic> file, {bool trashed = false, String? idOverride}) {
+    return CloudFileObject(
+      fileName: file['name'] as String?,
+      // Deleted-file metadata (`.tag == 'deleted'`) carries no `id` field at
+      // all (only live FileMetadata does) — callers resolving a possibly-
+      // trashed file pass the already-known query key as [idOverride].
+      id: idOverride ?? file['id'] as String,
+      description: null,
+      sizeInBytes: file['size'] as int?,
+      createdAt: DateTime.tryParse(file['client_modified'] as String? ?? ''),
+      modifiedAt: DateTime.tryParse(file['server_modified'] as String? ?? ''),
+      trashed: trashed,
+    );
+  }
+
   factory CloudFileObject.fromLegacyStoryPad(drive.File file) {
     return CloudFileObject(
       fileName: file.name,

--- a/lib/core/objects/dropbox_user_object.dart
+++ b/lib/core/objects/dropbox_user_object.dart
@@ -1,0 +1,58 @@
+import 'package:copy_with_extension/copy_with_extension.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:storypad/core/objects/cloud_service_user.dart';
+import 'package:storypad/core/services/backups/backup_service_type.dart';
+
+part 'dropbox_user_object.g.dart';
+
+@CopyWith()
+@JsonSerializable()
+class DropboxUserObject extends CloudServiceUser {
+  /// Dropbox's `account_id` (from `/2/users/get_current_account`) — a real,
+  /// stable, cross-device identity, unlike Nextcloud/iCloud's derived IDs.
+  final String id;
+  final String email;
+
+  @override
+  final String? displayName;
+
+  @override
+  final String? photoUrl;
+
+  final String accessToken;
+  final String refreshToken;
+  final DateTime accessTokenExpiresAt;
+
+  @override
+  final bool? autoBackupEnabled;
+
+  @override
+  BackupServiceType get serviceType => BackupServiceType.dropbox;
+
+  DropboxUserObject({
+    required this.id,
+    required this.email,
+    required this.displayName,
+    required this.photoUrl,
+    required this.accessToken,
+    required this.refreshToken,
+    required this.accessTokenExpiresAt,
+    required this.autoBackupEnabled,
+  });
+
+  @override
+  String get identifier => email;
+
+  @override
+  String? get globalId => serviceType.hasGlobalUserId ? "${serviceType.id}_$id" : null;
+
+  /// A short buffer before the real expiry so a request never races a
+  /// just-expired token — mirrors the intent of [GoogleUserObject]'s
+  /// refreshed-recently check, but keyed off the token's own expiry instead
+  /// of a fixed renewal window, since Dropbox tells us the exact lifetime.
+  bool get accessTokenExpiredOrExpiringSoon =>
+      DateTime.now().isAfter(accessTokenExpiresAt.subtract(const Duration(minutes: 2)));
+
+  Map<String, dynamic> toJson() => _$DropboxUserObjectToJson(this);
+  factory DropboxUserObject.fromJson(Map<String, dynamic> json) => _$DropboxUserObjectFromJson(json);
+}

--- a/lib/core/objects/dropbox_user_object.g.dart
+++ b/lib/core/objects/dropbox_user_object.g.dart
@@ -1,0 +1,177 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'dropbox_user_object.dart';
+
+// **************************************************************************
+// CopyWithGenerator
+// **************************************************************************
+
+abstract class _$DropboxUserObjectCWProxy {
+  DropboxUserObject id(String id);
+
+  DropboxUserObject email(String email);
+
+  DropboxUserObject displayName(String? displayName);
+
+  DropboxUserObject photoUrl(String? photoUrl);
+
+  DropboxUserObject accessToken(String accessToken);
+
+  DropboxUserObject refreshToken(String refreshToken);
+
+  DropboxUserObject accessTokenExpiresAt(DateTime accessTokenExpiresAt);
+
+  DropboxUserObject autoBackupEnabled(bool? autoBackupEnabled);
+
+  /// Creates a new instance with the provided field values.
+  /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `DropboxUserObject(...).copyWith.fieldName(value)`.
+  ///
+  /// Example:
+  /// ```dart
+  /// DropboxUserObject(...).copyWith(id: 12, name: "My name")
+  /// ```
+  DropboxUserObject call({
+    String id,
+    String email,
+    String? displayName,
+    String? photoUrl,
+    String accessToken,
+    String refreshToken,
+    DateTime accessTokenExpiresAt,
+    bool? autoBackupEnabled,
+  });
+}
+
+/// Callable proxy for `copyWith` functionality.
+/// Use as `instanceOfDropboxUserObject.copyWith(...)` or call `instanceOfDropboxUserObject.copyWith.fieldName(value)` for a single field.
+class _$DropboxUserObjectCWProxyImpl implements _$DropboxUserObjectCWProxy {
+  const _$DropboxUserObjectCWProxyImpl(this._value);
+
+  final DropboxUserObject _value;
+
+  @override
+  DropboxUserObject id(String id) => call(id: id);
+
+  @override
+  DropboxUserObject email(String email) => call(email: email);
+
+  @override
+  DropboxUserObject displayName(String? displayName) =>
+      call(displayName: displayName);
+
+  @override
+  DropboxUserObject photoUrl(String? photoUrl) => call(photoUrl: photoUrl);
+
+  @override
+  DropboxUserObject accessToken(String accessToken) =>
+      call(accessToken: accessToken);
+
+  @override
+  DropboxUserObject refreshToken(String refreshToken) =>
+      call(refreshToken: refreshToken);
+
+  @override
+  DropboxUserObject accessTokenExpiresAt(DateTime accessTokenExpiresAt) =>
+      call(accessTokenExpiresAt: accessTokenExpiresAt);
+
+  @override
+  DropboxUserObject autoBackupEnabled(bool? autoBackupEnabled) =>
+      call(autoBackupEnabled: autoBackupEnabled);
+
+  /// Creates a new instance with the provided field values.
+  /// Passing `null` to a nullable field nullifies it, while `null` for a non-nullable field is ignored. To update a single field use `DropboxUserObject(...).copyWith.fieldName(value)`.
+  ///
+  /// Example:
+  /// ```dart
+  /// DropboxUserObject(...).copyWith(id: 12, name: "My name")
+  /// ```
+  @override
+  DropboxUserObject call({
+    Object? id = const $CopyWithPlaceholder(),
+    Object? email = const $CopyWithPlaceholder(),
+    Object? displayName = const $CopyWithPlaceholder(),
+    Object? photoUrl = const $CopyWithPlaceholder(),
+    Object? accessToken = const $CopyWithPlaceholder(),
+    Object? refreshToken = const $CopyWithPlaceholder(),
+    Object? accessTokenExpiresAt = const $CopyWithPlaceholder(),
+    Object? autoBackupEnabled = const $CopyWithPlaceholder(),
+  }) {
+    return DropboxUserObject(
+      id: id == const $CopyWithPlaceholder() || id == null
+          ? _value.id
+          // ignore: cast_nullable_to_non_nullable
+          : id as String,
+      email: email == const $CopyWithPlaceholder() || email == null
+          ? _value.email
+          // ignore: cast_nullable_to_non_nullable
+          : email as String,
+      displayName: displayName == const $CopyWithPlaceholder()
+          ? _value.displayName
+          // ignore: cast_nullable_to_non_nullable
+          : displayName as String?,
+      photoUrl: photoUrl == const $CopyWithPlaceholder()
+          ? _value.photoUrl
+          // ignore: cast_nullable_to_non_nullable
+          : photoUrl as String?,
+      accessToken:
+          accessToken == const $CopyWithPlaceholder() || accessToken == null
+          ? _value.accessToken
+          // ignore: cast_nullable_to_non_nullable
+          : accessToken as String,
+      refreshToken:
+          refreshToken == const $CopyWithPlaceholder() || refreshToken == null
+          ? _value.refreshToken
+          // ignore: cast_nullable_to_non_nullable
+          : refreshToken as String,
+      accessTokenExpiresAt:
+          accessTokenExpiresAt == const $CopyWithPlaceholder() ||
+              accessTokenExpiresAt == null
+          ? _value.accessTokenExpiresAt
+          // ignore: cast_nullable_to_non_nullable
+          : accessTokenExpiresAt as DateTime,
+      autoBackupEnabled: autoBackupEnabled == const $CopyWithPlaceholder()
+          ? _value.autoBackupEnabled
+          // ignore: cast_nullable_to_non_nullable
+          : autoBackupEnabled as bool?,
+    );
+  }
+}
+
+extension $DropboxUserObjectCopyWith on DropboxUserObject {
+  /// Returns a callable class used to build a new instance with modified fields.
+  /// Example: `instanceOfDropboxUserObject.copyWith(...)` or `instanceOfDropboxUserObject.copyWith.fieldName(...)`.
+  // ignore: library_private_types_in_public_api
+  _$DropboxUserObjectCWProxy get copyWith =>
+      _$DropboxUserObjectCWProxyImpl(this);
+}
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DropboxUserObject _$DropboxUserObjectFromJson(Map<String, dynamic> json) =>
+    DropboxUserObject(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['display_name'] as String?,
+      photoUrl: json['photo_url'] as String?,
+      accessToken: json['access_token'] as String,
+      refreshToken: json['refresh_token'] as String,
+      accessTokenExpiresAt: DateTime.parse(
+        json['access_token_expires_at'] as String,
+      ),
+      autoBackupEnabled: json['auto_backup_enabled'] as bool?,
+    );
+
+Map<String, dynamic> _$DropboxUserObjectToJson(
+  DropboxUserObject instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'email': instance.email,
+  'display_name': instance.displayName,
+  'photo_url': instance.photoUrl,
+  'access_token': instance.accessToken,
+  'refresh_token': instance.refreshToken,
+  'access_token_expires_at': instance.accessTokenExpiresAt.toIso8601String(),
+  'auto_backup_enabled': instance.autoBackupEnabled,
+};

--- a/lib/core/repositories/backup_repository.dart
+++ b/lib/core/repositories/backup_repository.dart
@@ -12,10 +12,12 @@ import 'package:storypad/core/objects/backup_exceptions/backup_exception.dart' a
 import 'package:storypad/core/objects/backup_object.dart';
 import 'package:storypad/core/objects/cloud_file_object.dart';
 import 'package:storypad/core/objects/cloud_service_user.dart';
+import 'package:storypad/core/objects/dropbox_user_object.dart';
 import 'package:storypad/core/objects/google_user_object.dart';
 import 'package:storypad/core/objects/icloud_user_object.dart';
 import 'package:storypad/core/objects/nextcloud_user_object.dart';
 import 'package:storypad/core/services/backups/backup_cloud_service.dart';
+import 'package:storypad/core/services/backups/dropbox_cloud_service.dart';
 import 'package:storypad/core/services/backups/nextcloud_cloud_service.dart';
 import 'package:storypad/core/services/backups/backup_service_type.dart';
 import 'package:storypad/core/services/backups/sync_steps/backup_sync_message.dart';
@@ -79,6 +81,11 @@ class BackupRepository {
   /// disabled placeholder for iCloud; it's simply absent from [services]
   /// there, so no connect tile renders. See `BackupProvider._createICloudService`.
   final BackupCloudService? icloudService;
+
+  /// Unlike iCloud, Dropbox is pure REST — it works identically on every
+  /// platform this app targets, so there's no platform gate and no
+  /// disabled-stub case the way Drive's Linux build needs.
+  final DropboxCloudService dropboxService;
   final BackupSyncMessenger messenger;
 
   final BackupImagesUploaderService _step1ImagesUploader;
@@ -92,6 +99,7 @@ class BackupRepository {
     required this.googleDriveService,
     required this.nextcloudService,
     required this.icloudService,
+    required this.dropboxService,
     required this.restoreService,
     required this.messenger,
     required BackupImagesUploaderService step1ImagesUploader,
@@ -111,12 +119,14 @@ class BackupRepository {
     await googleDriveService.initialize();
     await nextcloudService.initialize();
     await icloudService?.initialize();
+    await dropboxService.initialize();
   }
 
   // currentUser & isSignedIn are load in initializer - before rendering UI.
   GoogleUserObject? get currentGoogleUser => googleDriveService.currentUser as GoogleUserObject?;
   NextcloudUserObject? get currentNextcloudUser => nextcloudService.currentUser;
   ICloudUserObject? get currentICloudUser => icloudService?.currentUser as ICloudUserObject?;
+  DropboxUserObject? get currentDropboxUser => dropboxService.currentUser;
   bool get isSignedIn => availableUsers.isNotEmpty;
 
   /// Get all authenticated cloud service users for asset downloads
@@ -165,6 +175,7 @@ class BackupRepository {
   List<BackupCloudService> get services => [
     googleDriveService,
     ?icloudService,
+    dropboxService,
     nextcloudService,
   ];
 

--- a/lib/core/services/backups/backup_service_type.dart
+++ b/lib/core/services/backups/backup_service_type.dart
@@ -5,19 +5,24 @@ import 'package:storypad/widgets/sp_icons.dart';
 
 enum BackupServiceType {
   google_drive(id: 'google_drive', displayName: 'Google Drive', hasGlobalUserId: true),
-  nextcloud(id: 'nextcloud', displayName: 'Nextcloud', hasGlobalUserId: true),
   // CloudKit's fetchUserRecordID gives a real, stable per-account identifier
   // — aliased into RevenueCat identity same as Drive/Nextcloud. See
   // ICloudUserObject.globalId.
-  icloud(id: 'icloud', displayName: 'iCloud', hasGlobalUserId: true);
+  icloud(id: 'icloud', displayName: 'iCloud', hasGlobalUserId: true),
+  // Dropbox's account_id (from /2/users/get_current_account) is a real,
+  // stable, cross-device identity — same aliasing scheme as Drive/iCloud.
+  // See DropboxUserObject.globalId.
+  dropbox(id: 'dropbox', displayName: 'Dropbox', hasGlobalUserId: true),
+  nextcloud(id: 'nextcloud', displayName: 'Nextcloud', hasGlobalUserId: true);
 
   final String id;
   final String displayName;
   final bool hasGlobalUserId;
 
   bool get googleDrive => this == google_drive;
-  bool get nextcloudService => this == nextcloud;
   bool get icloudService => this == icloud;
+  bool get dropboxService => this == dropbox;
+  bool get nextcloudService => this == nextcloud;
 
   /// Only Google Drive syncs for free — Nextcloud and iCloud require Pro.
   bool get isProOnly => this != google_drive;
@@ -39,6 +44,8 @@ enum BackupServiceType {
         return SpIcons.nextcloud;
       case BackupServiceType.icloud:
         return SpIcons.icloud;
+      case BackupServiceType.dropbox:
+        return SpIcons.dropbox;
     }
   }
 }

--- a/lib/core/services/backups/dropbox_cloud_service.dart
+++ b/lib/core/services/backups/dropbox_cloud_service.dart
@@ -216,6 +216,26 @@ class DropboxCloudService extends BackupCloudService {
     throw _DropboxApiException(response.statusCode, response.body);
   }
 
+  /// Dropbox reports most "no such file" conditions as HTTP 409, but 409 also
+  /// covers many *other*, distinct structured errors (`restricted_content`,
+  /// `malformed_path`, ...) — treating every 409 as "not found" would
+  /// silently swallow those into a missing backup instead of surfacing them.
+  /// `error_summary` is a stable, always-present plain string Dropbox
+  /// includes on every structured error response, so it's checked instead of
+  /// just the status code.
+  bool _isPathNotFound(http.Response response) {
+    if (response.statusCode != 409) return false;
+    return _errorSummary(response.body)?.startsWith('path/not_found') == true;
+  }
+
+  String? _errorSummary(String body) {
+    try {
+      return (jsonDecode(body) as Map<String, dynamic>)['error_summary'] as String?;
+    } catch (_) {
+      return null;
+    }
+  }
+
   String _filePath(String fileName, {String? folderName}) =>
       folderName != null ? '/$folderName/$fileName' : '/$fileName';
 
@@ -287,7 +307,7 @@ class DropboxCloudService extends BackupCloudService {
       },
     );
 
-    if (swallow404 && response.statusCode == 409) return null;
+    if (swallow404 && _isPathNotFound(response)) return null;
     _throwIfError(response);
     return response.bodyBytes;
   }
@@ -298,7 +318,7 @@ class DropboxCloudService extends BackupCloudService {
       methodName: 'findFileById',
       operation: () async {
         final response = await _postJson(_apiUri('files/get_metadata'), {'path': fileId});
-        if (response.statusCode == 409) return null;
+        if (_isPathNotFound(response)) return null;
         _throwIfError(response);
 
         final body = jsonDecode(response.body) as Map<String, dynamic>;
@@ -317,7 +337,7 @@ class DropboxCloudService extends BackupCloudService {
           'path': fileId,
           'include_deleted': true,
         });
-        if (response.statusCode == 409) return null;
+        if (_isPathNotFound(response)) return null;
         _throwIfError(response);
 
         final body = jsonDecode(response.body) as Map<String, dynamic>;
@@ -499,7 +519,7 @@ class DropboxCloudService extends BackupCloudService {
   }) async {
     var response = await _postJson(_apiUri('files/list_folder'), {'path': folderPath, 'recursive': recursive});
 
-    if (swallow404 && response.statusCode == 409) return [];
+    if (swallow404 && _isPathNotFound(response)) return [];
     _throwIfError(response);
 
     final entries = <Map<String, dynamic>>[];
@@ -588,9 +608,9 @@ class DropboxCloudService extends BackupCloudService {
       }
 
       if (error.statusCode == 409) {
-        final lowerBody = error.body.toLowerCase();
+        final summary = _errorSummary(error.body) ?? '';
 
-        if (lowerBody.contains('not_found')) {
+        if (summary.startsWith('path/not_found')) {
           return exp.FileOperationException(
             'File not found during $methodName',
             _getFileOperationType(methodName),
@@ -600,7 +620,7 @@ class DropboxCloudService extends BackupCloudService {
           );
         }
 
-        if (lowerBody.contains('insufficient_space')) {
+        if (summary.contains('insufficient_space')) {
           return exp.QuotaException(
             'Storage quota exceeded during $methodName',
             exp.QuotaExceptionType.storageQuotaExceeded,

--- a/lib/core/services/backups/dropbox_cloud_service.dart
+++ b/lib/core/services/backups/dropbox_cloud_service.dart
@@ -1,0 +1,651 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:http/http.dart' as http;
+import 'package:storypad/core/objects/backup_exceptions/backup_exception.dart' as exp;
+import 'package:storypad/core/objects/cloud_file_object.dart';
+import 'package:storypad/core/objects/cloud_storage_quota_object.dart';
+import 'package:storypad/core/objects/dropbox_user_object.dart';
+import 'package:storypad/core/services/backups/backup_cloud_service.dart';
+import 'package:storypad/core/services/backups/backup_service_type.dart';
+import 'package:storypad/core/services/backups/dropbox_oauth_service.dart';
+import 'package:storypad/core/services/logger/app_logger.dart';
+import 'package:storypad/core/storages/dropbox_user_storage.dart';
+
+/// Thrown for any non-2xx Dropbox API response — classified into a typed
+/// [exp.BackupException] by [DropboxCloudService._buildException]. Dropbox
+/// reports most errors as HTTP 409 with a structured JSON body rather than
+/// distinct status codes per error kind, so the body has to be inspected too.
+class _DropboxApiException implements Exception {
+  final int statusCode;
+  final String body;
+  _DropboxApiException(this.statusCode, this.body);
+
+  @override
+  String toString() => 'DropboxApiException($statusCode): $body';
+}
+
+/// Dropbox backup target — plain REST over `api.dropboxapi.com` /
+/// `content.dropboxapi.com`, no SDK (Dropbox doesn't publish one for Dart).
+///
+/// Runs entirely client-side: [DropboxOAuthService] performs the OAuth2 PKCE
+/// flow for public/native clients, so there's no client secret anywhere and
+/// no backend involved (see docs/app/architecture/backup-sync.md). The app
+/// requests **App folder** access — every path here is already relative to
+/// the app's sandboxed `Apps/StoryPad` folder, so unlike Nextcloud there's no
+/// customizable root folder to thread through.
+///
+/// Two things make this closer to Drive than to Nextcloud/iCloud:
+/// - Dropbox assigns real stable file IDs (`id:xxxx`) independent of path, so
+///   [CloudFileObject.id] is that ID, not a path.
+/// - `files/delete_v2` already soft-deletes into Dropbox's own native trash —
+///   no manual `.trash/`-folder emulation is needed. Restoring a deleted file
+///   is done by finding its most recent revision (`files/list_revisions`,
+///   since deleted-file metadata carries no `rev`) and restoring that
+///   revision's path (`files/restore`) — Dropbox has no separate "undelete".
+class DropboxCloudService extends BackupCloudService {
+  final DropboxOAuthService _oauth = DropboxOAuthService();
+
+  @override
+  BackupServiceType get serviceType => BackupServiceType.dropbox;
+
+  DropboxUserObject? _currentUser;
+
+  @override
+  DropboxUserObject? get currentUser => _currentUser;
+
+  @override
+  bool get isSignedIn => _currentUser != null;
+
+  @override
+  Future<void> initialize() async {
+    _currentUser = await DropboxUserStorage().readObject();
+  }
+
+  @override
+  void setAutoBackupEnabled(bool enabled) {
+    if (_currentUser == null) return;
+
+    _currentUser = _currentUser!.copyWith(autoBackupEnabled: enabled);
+    DropboxUserStorage().writeObject(_currentUser!);
+  }
+
+  @override
+  Future<bool> signIn() async {
+    try {
+      final tokens = await _oauth.authenticate();
+      final refreshToken = tokens.refreshToken;
+      if (refreshToken == null) {
+        throw exp.AuthException(
+          'Dropbox did not return a refresh token (token_access_type=offline missing?)',
+          exp.AuthExceptionType.signInFailed,
+          context: 'signIn',
+          serviceType: serviceType,
+        );
+      }
+
+      final account = await _fetchAccount(accessToken: tokens.accessToken);
+
+      _currentUser = DropboxUserObject(
+        id: account.id,
+        email: account.email,
+        displayName: account.displayName,
+        photoUrl: account.photoUrl,
+        accessToken: tokens.accessToken,
+        refreshToken: refreshToken,
+        accessTokenExpiresAt: tokens.expiresAt,
+        autoBackupEnabled: autoBackupEnabled,
+      );
+
+      await DropboxUserStorage().writeObject(_currentUser!);
+      return true;
+    } catch (e) {
+      if (e is exp.AuthException) rethrow;
+      throw exp.AuthException(
+        'Sign-in failed: $e',
+        exp.AuthExceptionType.signInFailed,
+        context: 'signIn',
+        serviceType: serviceType,
+      );
+    }
+  }
+
+  @override
+  Future<void> signOut() async {
+    await DropboxUserStorage().remove();
+    _currentUser = null;
+  }
+
+  @override
+  Future<bool> reauthenticateIfNeeded() async {
+    final user = _currentUser;
+    if (user == null) {
+      throw exp.AuthException(
+        'No stored user found',
+        exp.AuthExceptionType.signInRequired,
+        serviceType: serviceType,
+      );
+    }
+
+    if (!user.accessTokenExpiredOrExpiringSoon) return true;
+
+    final refreshed = await _oauth.refresh(refreshToken: user.refreshToken);
+    if (refreshed == null) {
+      throw exp.AuthException(
+        'Dropbox refresh token was revoked',
+        exp.AuthExceptionType.tokenRevoked,
+        context: 'reauthenticateIfNeeded',
+        serviceType: serviceType,
+      );
+    }
+
+    _currentUser = user.copyWith(
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken ?? user.refreshToken,
+      accessTokenExpiresAt: refreshed.expiresAt,
+    );
+    await DropboxUserStorage().writeObject(_currentUser!);
+    return true;
+  }
+
+  /// Dropbox's permission scopes are fixed at consent time in the app
+  /// console, not requested incrementally at runtime like Drive's — so
+  /// there's nothing to actually check beyond being signed in at all.
+  @override
+  Future<bool> canAccessRequestedScopes() async => isSignedIn;
+
+  @override
+  Future<bool> requestScope() async => isSignedIn;
+
+  ({String id, String email, String? displayName, String? photoUrl}) _parseAccount(Map<String, dynamic> body) {
+    final name = body['name'] as Map<String, dynamic>?;
+    return (
+      id: body['account_id'] as String,
+      email: body['email'] as String,
+      displayName: name?['display_name'] as String?,
+      photoUrl: body['profile_photo_url'] as String?,
+    );
+  }
+
+  Future<({String id, String email, String? displayName, String? photoUrl})> _fetchAccount({
+    required String accessToken,
+  }) async {
+    final response = await http.post(
+      _apiUri('users/get_current_account'),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+
+    if (response.statusCode != 200) {
+      throw exp.AuthException(
+        'Failed to fetch Dropbox account: ${response.body}',
+        exp.AuthExceptionType.signInFailed,
+        context: 'signIn',
+        serviceType: serviceType,
+      );
+    }
+
+    return _parseAccount(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  Uri _apiUri(String endpoint) => Uri.parse('https://api.dropboxapi.com/2/$endpoint');
+  Uri _contentUri(String endpoint) => Uri.parse('https://content.dropboxapi.com/2/$endpoint');
+
+  Map<String, String> get _authHeader {
+    final user = _currentUser;
+    if (user == null) {
+      throw exp.AuthException(
+        'Failed to get authenticated Dropbox client',
+        exp.AuthExceptionType.signInRequired,
+        serviceType: serviceType,
+      );
+    }
+    return {'Authorization': 'Bearer ${user.accessToken}'};
+  }
+
+  Future<http.Response> _postJson(Uri uri, Map<String, dynamic> body) {
+    return http.post(
+      uri,
+      headers: {..._authHeader, 'Content-Type': 'application/json'},
+      body: jsonEncode(body),
+    );
+  }
+
+  void _throwIfError(http.Response response) {
+    if (response.statusCode >= 200 && response.statusCode < 300) return;
+    throw _DropboxApiException(response.statusCode, response.body);
+  }
+
+  String _filePath(String fileName, {String? folderName}) =>
+      folderName != null ? '/$folderName/$fileName' : '/$fileName';
+
+  String _parentPath(String path) {
+    final index = path.lastIndexOf('/');
+    return index <= 0 ? '' : path.substring(0, index);
+  }
+
+  @override
+  Future<Map<int, CloudFileObject>> fetchYearlyBackups() async {
+    return _executeWithRetry(
+      methodName: 'fetchYearlyBackups',
+      operation: () async {
+        final files = await _listFolder('/backups', swallow404: true);
+
+        final Map<int, CloudFileObject> yearlyBackups = {};
+        for (final file in files) {
+          final cloudFile = CloudFileObject.fromDropbox(file);
+          final year = cloudFile.year;
+          if (year == null) continue;
+
+          final existing = yearlyBackups[year];
+          final existingTs = existing?.lastUpdatedAt;
+          final newTs = cloudFile.lastUpdatedAt;
+          final isNewer = existing == null || (newTs != null && (existingTs == null || newTs.isAfter(existingTs)));
+          if (isNewer) yearlyBackups[year] = cloudFile;
+        }
+
+        return yearlyBackups;
+      },
+    );
+  }
+
+  @override
+  Future<(String, int)?> getFileContent(CloudFileObject file) async {
+    return _executeWithRetry(
+      methodName: 'getFileContent',
+      operation: () async {
+        final bytes = await _downloadBytes(file.id, swallow404: true);
+        if (bytes == null) return null;
+
+        if (file.getFileInfo()?.hasCompression == true) {
+          final decoded = io.gzip.decode(bytes);
+          return (utf8.decode(decoded), bytes.length);
+        }
+
+        return (utf8.decode(bytes), bytes.length);
+      },
+    );
+  }
+
+  @override
+  Future<List<int>?> downloadFileBytes(String fileId) async {
+    return _executeWithRetry(
+      methodName: 'downloadFileBytes',
+      // Unlike getFileContent above, a not-found here must surface as a
+      // FileOperationException (via _buildException) rather than null — see
+      // BackupCloudService.downloadFileBytes's contract.
+      operation: () => _downloadBytes(fileId, swallow404: false),
+    );
+  }
+
+  Future<List<int>?> _downloadBytes(String fileIdOrPath, {required bool swallow404}) async {
+    final response = await http.post(
+      _contentUri('files/download'),
+      headers: {
+        ..._authHeader,
+        'Dropbox-API-Arg': jsonEncode({'path': fileIdOrPath}),
+      },
+    );
+
+    if (swallow404 && response.statusCode == 409) return null;
+    _throwIfError(response);
+    return response.bodyBytes;
+  }
+
+  @override
+  Future<CloudFileObject?> findFileById(String fileId) async {
+    return _executeWithRetry(
+      methodName: 'findFileById',
+      operation: () async {
+        final response = await _postJson(_apiUri('files/get_metadata'), {'path': fileId});
+        if (response.statusCode == 409) return null;
+        _throwIfError(response);
+
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        if (body['.tag'] != 'file') return null;
+        return CloudFileObject.fromDropbox(body);
+      },
+    );
+  }
+
+  @override
+  Future<CloudFileObject?> findFileByIdIncludingTrashed(String fileId) async {
+    return _executeWithRetry(
+      methodName: 'findFileByIdIncludingTrashed',
+      operation: () async {
+        final response = await _postJson(_apiUri('files/get_metadata'), {
+          'path': fileId,
+          'include_deleted': true,
+        });
+        if (response.statusCode == 409) return null;
+        _throwIfError(response);
+
+        final body = jsonDecode(response.body) as Map<String, dynamic>;
+        final trashed = body['.tag'] == 'deleted';
+        return CloudFileObject.fromDropbox(body, trashed: trashed, idOverride: trashed ? fileId : null);
+      },
+    );
+  }
+
+  @override
+  Future<bool> deleteFile(String cloudFileId) async {
+    return _executeWithRetry(
+      methodName: 'deleteFile',
+      operation: () async {
+        final response = await _postJson(_apiUri('files/delete_v2'), {'path': cloudFileId});
+        _throwIfError(response);
+        return true;
+      },
+    );
+  }
+
+  /// Dropbox's [deleteFile] already soft-deletes into its own native trash —
+  /// there's no separate "move to trash" call the way WebDAV/iCloud need.
+  @override
+  Future<bool> trashFile(String cloudFileId) => deleteFile(cloudFileId);
+
+  @override
+  Future<bool> restoreFileFromTrash(String cloudFileId) async {
+    return _executeWithRetry(
+      methodName: 'restoreFileFromTrash',
+      operation: () async {
+        final metadataResponse = await _postJson(_apiUri('files/get_metadata'), {
+          'path': cloudFileId,
+          'include_deleted': true,
+        });
+        _throwIfError(metadataResponse);
+        final metadata = jsonDecode(metadataResponse.body) as Map<String, dynamic>;
+        final path = metadata['path_lower'] as String;
+
+        // Deleted-file metadata carries no `rev` (only live FileMetadata
+        // does), so the path's most recent revision has to be looked up
+        // first — restoring that revision's path is Dropbox's documented way
+        // to undelete a file; there's no separate "undelete" endpoint.
+        final revisionsResponse = await _postJson(_apiUri('files/list_revisions'), {
+          'path': path,
+          'mode': 'path',
+          'limit': 1,
+        });
+        _throwIfError(revisionsResponse);
+        final revisions = jsonDecode(revisionsResponse.body) as Map<String, dynamic>;
+        final entries = (revisions['entries'] as List).cast<Map<String, dynamic>>();
+        if (entries.isEmpty) {
+          throw exp.FileOperationException(
+            'No revisions found to restore',
+            exp.FileOperationType.delete,
+            context: cloudFileId,
+            serviceType: serviceType,
+          );
+        }
+
+        final rev = entries.first['rev'] as String;
+        final restoreResponse = await _postJson(_apiUri('files/restore'), {'path': path, 'rev': rev});
+        _throwIfError(restoreResponse);
+        return true;
+      },
+    );
+  }
+
+  @override
+  Future<CloudFileObject?> uploadFile(
+    String fileName,
+    io.File file, {
+    String? folderName,
+  }) async {
+    return _executeWithRetry(
+      methodName: 'uploadFile',
+      operation: () async {
+        if (!file.existsSync()) {
+          throw exp.FileOperationException(
+            'Local file does not exist: ${file.path}',
+            exp.FileOperationType.upload,
+            context: fileName,
+            serviceType: serviceType,
+          );
+        }
+
+        final path = _filePath(fileName, folderName: folderName);
+        final bytes = await file.readAsBytes();
+
+        final response = await http.post(
+          _contentUri('files/upload'),
+          headers: {
+            ..._authHeader,
+            'Dropbox-API-Arg': jsonEncode({'path': path, 'mode': 'overwrite', 'mute': true}),
+            'Content-Type': 'application/octet-stream',
+          },
+          body: bytes,
+        );
+        _throwIfError(response);
+
+        return CloudFileObject.fromDropbox(jsonDecode(response.body) as Map<String, dynamic>);
+      },
+    );
+  }
+
+  @override
+  Future<CloudFileObject?> updateFile({
+    required String fileId,
+    required String fileName,
+    required io.File file,
+  }) async {
+    return _executeWithRetry(
+      methodName: 'updateFile',
+      operation: () async {
+        if (!file.existsSync()) {
+          throw exp.FileOperationException(
+            'Local file does not exist: ${file.path}',
+            exp.FileOperationType.upload,
+            context: fileName,
+            serviceType: serviceType,
+          );
+        }
+
+        // Yearly backup filenames embed a timestamp, so an "update" writes a
+        // new path in the same folder — the old file's own path has to be
+        // looked up from its ID first (Dropbox content endpoints take a
+        // path, not a bare ID).
+        final oldMetadataResponse = await _postJson(_apiUri('files/get_metadata'), {'path': fileId});
+        _throwIfError(oldMetadataResponse);
+        final oldPath = (jsonDecode(oldMetadataResponse.body) as Map<String, dynamic>)['path_lower'] as String;
+        final folder = _parentPath(oldPath);
+        final newPath = folder.isEmpty ? '/$fileName' : '$folder/$fileName';
+
+        final bytes = await file.readAsBytes();
+        final uploadResponse = await http.post(
+          _contentUri('files/upload'),
+          headers: {
+            ..._authHeader,
+            'Dropbox-API-Arg': jsonEncode({'path': newPath, 'mode': 'overwrite', 'mute': true}),
+            'Content-Type': 'application/octet-stream',
+          },
+          body: bytes,
+        );
+        _throwIfError(uploadResponse);
+        final uploaded = jsonDecode(uploadResponse.body) as Map<String, dynamic>;
+
+        if (newPath.toLowerCase() != oldPath) {
+          try {
+            final deleteResponse = await _postJson(_apiUri('files/delete_v2'), {'path': fileId});
+            _throwIfError(deleteResponse);
+          } catch (e) {
+            AppLogger.d('DropboxCloudService#updateFile: failed to remove old file $fileId: $e');
+          }
+        }
+
+        return CloudFileObject.fromDropbox(uploaded);
+      },
+    );
+  }
+
+  @override
+  Future<List<CloudFileObject>> listFilesInFolder(String folderName) async {
+    return _executeWithRetry(
+      methodName: 'listFilesInFolder',
+      operation: () async {
+        final files = await _listFolder('/$folderName', swallow404: true);
+        return files.map((file) => CloudFileObject.fromDropbox(file)).toList();
+      },
+    );
+  }
+
+  /// [folderPath] must be `''` for the app-folder root (Dropbox's own
+  /// convention — `'/'` is rejected), or `/name` otherwise. Handles
+  /// `list_folder`/`list_folder/continue` pagination internally.
+  Future<List<Map<String, dynamic>>> _listFolder(
+    String folderPath, {
+    bool swallow404 = false,
+    bool recursive = false,
+  }) async {
+    var response = await _postJson(_apiUri('files/list_folder'), {'path': folderPath, 'recursive': recursive});
+
+    if (swallow404 && response.statusCode == 409) return [];
+    _throwIfError(response);
+
+    final entries = <Map<String, dynamic>>[];
+    var body = jsonDecode(response.body) as Map<String, dynamic>;
+    entries.addAll((body['entries'] as List).cast<Map<String, dynamic>>());
+
+    while (body['has_more'] == true) {
+      response = await _postJson(_apiUri('files/list_folder/continue'), {'cursor': body['cursor']});
+      _throwIfError(response);
+      body = jsonDecode(response.body) as Map<String, dynamic>;
+      entries.addAll((body['entries'] as List).cast<Map<String, dynamic>>());
+    }
+
+    return entries.where((entry) => entry['.tag'] == 'file').toList();
+  }
+
+  @override
+  Future<CloudStorageQuotaObject?> fetchStorageQuota() async {
+    if (_currentUser == null) return null;
+
+    try {
+      final files = await _listFolder('', swallow404: true, recursive: true);
+      final appUsage = files.fold<int>(0, (total, file) => total + ((file['size'] as int?) ?? 0));
+
+      final spaceResponse = await _postJson(_apiUri('users/get_space_usage'), {});
+      _throwIfError(spaceResponse);
+      final space = jsonDecode(spaceResponse.body) as Map<String, dynamic>;
+      final allocation = space['allocation'] as Map<String, dynamic>?;
+
+      return CloudStorageQuotaObject(
+        appUsageInBytes: appUsage,
+        accountUsageInBytes: space['used'] as int?,
+        limitInBytes: allocation?['allocated'] as int?,
+      );
+    } catch (e, s) {
+      AppLogger.error('DropboxCloudService#fetchStorageQuota failed: $e', stackTrace: s);
+      return null;
+    }
+  }
+
+  Future<T> _executeWithRetry<T>({
+    required String methodName,
+    required Future<T> Function() operation,
+  }) async {
+    try {
+      return await operation();
+    } catch (e) {
+      final exception = _buildException(e, methodName);
+
+      if (exception is exp.AuthException && exception.requiresReauth) {
+        final reauthenticated = await reauthenticateIfNeeded();
+
+        if (reauthenticated) {
+          try {
+            return await operation();
+          } catch (e) {
+            throw _buildException(e, methodName);
+          }
+        }
+      }
+
+      throw exception;
+    }
+  }
+
+  exp.BackupException _buildException(dynamic error, String methodName) {
+    if (error is exp.BackupException) return error;
+
+    if (error is _DropboxApiException) {
+      if (error.statusCode == 401) {
+        return exp.AuthException(
+          'Authentication failed during $methodName',
+          exp.AuthExceptionType.tokenExpired,
+          context: methodName,
+          serviceType: serviceType,
+        );
+      }
+
+      if (error.statusCode == 429) {
+        return exp.QuotaException(
+          'Rate limit exceeded during $methodName',
+          exp.QuotaExceptionType.rateLimitExceeded,
+          context: methodName,
+          serviceType: serviceType,
+        );
+      }
+
+      if (error.statusCode == 409) {
+        final lowerBody = error.body.toLowerCase();
+
+        if (lowerBody.contains('not_found')) {
+          return exp.FileOperationException(
+            'File not found during $methodName',
+            _getFileOperationType(methodName),
+            context: methodName,
+            serviceType: serviceType,
+            statusCode: 404,
+          );
+        }
+
+        if (lowerBody.contains('insufficient_space')) {
+          return exp.QuotaException(
+            'Storage quota exceeded during $methodName',
+            exp.QuotaExceptionType.storageQuotaExceeded,
+            context: methodName,
+            serviceType: serviceType,
+          );
+        }
+      }
+
+      return exp.ServiceException(
+        'Dropbox API error during $methodName (${error.statusCode}): ${error.body}',
+        exp.ServiceExceptionType.unexpectedError,
+        context: methodName,
+        serviceType: serviceType,
+      );
+    }
+
+    if (error is io.SocketException || error is TimeoutException) {
+      return exp.NetworkException(
+        'Network error during $methodName: $error',
+        context: methodName,
+        serviceType: serviceType,
+      );
+    }
+
+    return exp.ServiceException(
+      'Unknown error during $methodName: $error',
+      exp.ServiceExceptionType.unexpectedError,
+      context: methodName,
+      serviceType: serviceType,
+    );
+  }
+
+  exp.FileOperationType _getFileOperationType(String methodName) {
+    switch (methodName) {
+      case 'uploadFile':
+      case 'updateFile':
+        return exp.FileOperationType.upload;
+      case 'deleteFile':
+        return exp.FileOperationType.delete;
+      case 'getFileContent':
+      case 'downloadFileBytes':
+        return exp.FileOperationType.download;
+      default:
+        return exp.FileOperationType.list;
+    }
+  }
+}

--- a/lib/core/services/backups/dropbox_oauth_service.dart
+++ b/lib/core/services/backups/dropbox_oauth_service.dart
@@ -74,7 +74,11 @@ class DropboxOAuthService {
     return base64UrlEncode(bytes).replaceAll('=', '');
   }
 
-  String _codeChallengeFor(String codeVerifier) {
+  /// PKCE's `code_challenge` derivation (RFC 7636 §4.2, S256 method) — pure
+  /// over its input, so exposed as a public static method for direct testing
+  /// (same reasoning as `NextcloudCloudService.sanitizeFolderName`), unlike
+  /// the rest of this class which needs live network/browser interaction.
+  static String codeChallengeFor(String codeVerifier) {
     final digest = sha256.convert(utf8.encode(codeVerifier));
     return base64UrlEncode(digest.bytes).replaceAll('=', '');
   }
@@ -85,7 +89,7 @@ class DropboxOAuthService {
   /// same [DropboxCloudService] exception mapping used for every other call.
   Future<DropboxTokenResponse> authenticate() async {
     final codeVerifier = _generateCodeVerifier();
-    final codeChallenge = _codeChallengeFor(codeVerifier);
+    final codeChallenge = codeChallengeFor(codeVerifier);
     final redirectUri = _redirectUri;
     final useWebview = !(!kIsWeb && io.Platform.isLinux);
 
@@ -105,7 +109,13 @@ class DropboxOAuthService {
 
     final result = await FlutterWebAuth2.authenticate(
       url: authorizeUri.toString(),
-      callbackUrlScheme: Uri.parse(redirectUri).scheme,
+      // On every other platform this is just the scheme (ASWebAuthentication-
+      // Session/Custom Tabs match on it directly); Linux's loopback-server
+      // implementation (useWebview: false) instead parses this value as a
+      // full URI and requires the complete `http://localhost:{port}` string
+      // to bind the right port — passing just "http" throws before the
+      // browser even opens. See flutter_web_auth_2's FlutterWebAuth2ServerPlugin.
+      callbackUrlScheme: useWebview ? Uri.parse(redirectUri).scheme : redirectUri,
       options: FlutterWebAuth2Options(useWebview: useWebview),
     );
 

--- a/lib/core/services/backups/dropbox_oauth_service.dart
+++ b/lib/core/services/backups/dropbox_oauth_service.dart
@@ -1,0 +1,178 @@
+import 'dart:convert';
+import 'dart:io' as io;
+import 'dart:math';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_web_auth_2/flutter_web_auth_2.dart';
+import 'package:http/http.dart' as http;
+import 'package:storypad/core/constants/app_constants.dart';
+
+/// Result of a completed OAuth2 code exchange (initial sign-in) or refresh.
+class DropboxTokenResponse {
+  final String accessToken;
+  final String? refreshToken;
+  final DateTime expiresAt;
+
+  DropboxTokenResponse({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.expiresAt,
+  });
+}
+
+/// Runs Dropbox's OAuth2 **PKCE flow for public/native clients** — no client
+/// secret anywhere in this file, by design. [kDropboxAppKey] (the "App key")
+/// is not a secret; both the authorization-code exchange and the
+/// refresh-token exchange are plain unauthenticated-client requests per
+/// Dropbox's own docs, which is what lets this whole feature run fully
+/// client-side with no backend. See docs/app/architecture/backup-sync.md.
+class DropboxOAuthService {
+  static const _authorizeUrl = 'https://www.dropbox.com/oauth2/authorize';
+  static const _tokenUrl = 'https://api.dropboxapi.com/oauth2/token';
+
+  /// Fixed loopback port for the desktop (Linux) flow — flutter_web_auth_2's
+  /// `useWebview: false` path requires the callback to literally be
+  /// `http://localhost:{port}`, and Dropbox does exact redirect-URI matching,
+  /// so this must match whatever port is registered in the Dropbox app
+  /// console for the loopback redirect URI (see plans/2026-09-06-dropbox-backup-provider).
+  static const _linuxLoopbackPort = 8763;
+
+  /// Plain custom-scheme deep link for iOS/Android/macOS — deliberately not a
+  /// hosted HTTPS redirect (e.g. a `dropbox.storypad.me` Universal Link
+  /// endpoint): that pattern exists mainly to defend against a malicious app
+  /// intercepting the authorization code via the same custom scheme, which is
+  /// exactly what PKCE (the `code_challenge`/`code_verifier` pair below)
+  /// already defeats — an intercepted `code` is useless without the
+  /// `code_verifier`, which never leaves this process. So a hosted redirect
+  /// would add real infrastructure (Cloudflare Worker, DNS, and — to actually
+  /// get the security property back — Associated Domains/App Links
+  /// entitlements and `assetlinks.json`/AASA files per flavor) for no benefit
+  /// PKCE doesn't already provide.
+  ///
+  /// One literal scheme per flavor, matching the `dropboxCallbackScheme`
+  /// Gradle manifest placeholder in `android/app/build.gradle.kts`'s
+  /// `productFlavors` block and whatever's registered as the redirect URI in
+  /// the Dropbox app console. iOS/macOS need no matching Info.plist entry —
+  /// `ASWebAuthenticationSession` ties the callback to the session that
+  /// opened it, not to a system-wide URL-scheme registration.
+  String get _callbackUrlScheme {
+    if (kStoryPad) return 'storypad';
+    if (kCommunity) return 'spookycommunity';
+    if (kSpooky) return 'spooky';
+    throw StateError('Unknown flavor — no Dropbox OAuth callback scheme registered for this package');
+  }
+
+  String get _redirectUri {
+    if (!kIsWeb && io.Platform.isLinux) return 'http://localhost:$_linuxLoopbackPort/callback';
+    return '$_callbackUrlScheme://oauth/dropbox';
+  }
+
+  String _generateCodeVerifier() {
+    final random = Random.secure();
+    final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+    return base64UrlEncode(bytes).replaceAll('=', '');
+  }
+
+  String _codeChallengeFor(String codeVerifier) {
+    final digest = sha256.convert(utf8.encode(codeVerifier));
+    return base64UrlEncode(digest.bytes).replaceAll('=', '');
+  }
+
+  /// Runs the full interactive flow: opens the system browser / OS auth
+  /// session, waits for the redirect, then exchanges the code for tokens.
+  /// Throws on cancellation or any HTTP failure — callers classify via the
+  /// same [DropboxCloudService] exception mapping used for every other call.
+  Future<DropboxTokenResponse> authenticate() async {
+    final codeVerifier = _generateCodeVerifier();
+    final codeChallenge = _codeChallengeFor(codeVerifier);
+    final redirectUri = _redirectUri;
+    final useWebview = !(!kIsWeb && io.Platform.isLinux);
+
+    final authorizeUri = Uri.parse(_authorizeUrl).replace(
+      queryParameters: {
+        'client_id': kDropboxAppKey,
+        'response_type': 'code',
+        'code_challenge': codeChallenge,
+        'code_challenge_method': 'S256',
+        // Requests a long-lived refresh_token alongside the short-lived
+        // access_token — without this Dropbox only issues an access_token,
+        // forcing an interactive re-consent every few hours.
+        'token_access_type': 'offline',
+        'redirect_uri': redirectUri,
+      },
+    );
+
+    final result = await FlutterWebAuth2.authenticate(
+      url: authorizeUri.toString(),
+      callbackUrlScheme: Uri.parse(redirectUri).scheme,
+      options: FlutterWebAuth2Options(useWebview: useWebview),
+    );
+
+    final code = Uri.parse(result).queryParameters['code'];
+    if (code == null) {
+      throw const FormatException('Dropbox redirect did not include an authorization code');
+    }
+
+    return _exchangeCodeForTokens(code: code, codeVerifier: codeVerifier, redirectUri: redirectUri);
+  }
+
+  Future<DropboxTokenResponse> _exchangeCodeForTokens({
+    required String code,
+    required String codeVerifier,
+    required String redirectUri,
+  }) async {
+    final response = await http.post(
+      Uri.parse(_tokenUrl),
+      body: {
+        'code': code,
+        'grant_type': 'authorization_code',
+        'client_id': kDropboxAppKey,
+        'code_verifier': codeVerifier,
+        'redirect_uri': redirectUri,
+      },
+    );
+
+    return _parseTokenResponse(response);
+  }
+
+  /// Silent refresh — no browser, no user interaction. Returns null (rather
+  /// than throwing) only when Dropbox confirms the refresh token itself is
+  /// dead (`invalid_grant`), so callers can distinguish "needs a fresh
+  /// interactive sign-in" from a transient network/server failure.
+  Future<DropboxTokenResponse?> refresh({required String refreshToken}) async {
+    final response = await http.post(
+      Uri.parse(_tokenUrl),
+      body: {
+        'grant_type': 'refresh_token',
+        'refresh_token': refreshToken,
+        'client_id': kDropboxAppKey,
+      },
+    );
+
+    if (response.statusCode == 400) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      if (body['error'] == 'invalid_grant') return null;
+    }
+
+    return _parseTokenResponse(response, fallbackRefreshToken: refreshToken);
+  }
+
+  DropboxTokenResponse _parseTokenResponse(http.Response response, {String? fallbackRefreshToken}) {
+    if (response.statusCode != 200) {
+      throw http.ClientException('Dropbox token request failed (${response.statusCode}): ${response.body}');
+    }
+
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    final expiresInSeconds = body['expires_in'] as int;
+
+    return DropboxTokenResponse(
+      accessToken: body['access_token'] as String,
+      // A refresh response only includes refresh_token if Dropbox happens to
+      // rotate it — otherwise the original one is still valid and must be
+      // kept, or the next refresh would have nothing to refresh with.
+      refreshToken: body['refresh_token'] as String? ?? fallbackRefreshToken,
+      expiresAt: DateTime.now().add(Duration(seconds: expiresInSeconds)),
+    );
+  }
+}

--- a/lib/core/storages/dropbox_user_storage.dart
+++ b/lib/core/storages/dropbox_user_storage.dart
@@ -1,0 +1,15 @@
+import 'package:storypad/core/objects/dropbox_user_object.dart';
+import 'package:storypad/core/storages/base_object_storages/object_storage.dart';
+import 'package:storypad/core/storages/storage_adapters/base_storage_adapter.dart';
+import 'package:storypad/core/storages/storage_adapters/secure_storage_adaptor.dart';
+
+class DropboxUserStorage extends ObjectStorage<DropboxUserObject> {
+  @override
+  Future<BaseStorageAdapter<String>> get adapter async => SecureStorageAdaptor();
+
+  @override
+  DropboxUserObject decode(Map<String, dynamic> json) => DropboxUserObject.fromJson(json);
+
+  @override
+  Map<String, dynamic> encode(DropboxUserObject object) => object.toJson();
+}

--- a/lib/providers/backup_provider.dart
+++ b/lib/providers/backup_provider.dart
@@ -15,6 +15,7 @@ import 'package:storypad/core/services/analytics/analytics_service.dart';
 import 'package:storypad/core/services/assets/db_asset_loader_service.dart';
 import 'package:storypad/core/services/backups/backup_cloud_service.dart';
 import 'package:storypad/core/services/backups/backup_service_type.dart';
+import 'package:storypad/core/services/backups/dropbox_cloud_service.dart';
 import 'package:storypad/core/services/backups/google_drive_cloud_service.dart';
 import 'package:storypad/core/services/backups/google_drive_linux_cloud_service.dart';
 import 'package:storypad/core/services/backups/icloud_cloud_service.dart';
@@ -94,6 +95,7 @@ class BackupProvider extends ChangeNotifier with DebounchedCallback {
       googleDriveService: _createGoogleDriveService(),
       nextcloudService: NextcloudCloudService(),
       icloudService: _createICloudService(),
+      dropboxService: DropboxCloudService(),
       importHistoryStorage: BackupImportHistoryStorage(),
     );
   }
@@ -313,6 +315,28 @@ class BackupProvider extends ChangeNotifier with DebounchedCallback {
         final service = repository.getService(serviceType);
         if (service is ICloudCloudService) {
           await SpICloudSettingsSheet.show(context, service: service);
+        }
+      }
+      notifyListeners();
+      return;
+    }
+
+    // Dropbox runs its own interactive OAuth2 PKCE flow inside signIn() (no
+    // google_sign_in involved), so it can't share the generic branch below,
+    // which assumes success always means Drive — that call would otherwise
+    // mislabel a Dropbox connection as a Google sign-in in analytics.
+    if (serviceType == BackupServiceType.dropbox) {
+      if (result.isSuccess == true) {
+        AnalyticsService.instance.logLogin(loginMethod: 'dropbox');
+        _syncState.onConnectionChecked({serviceType: BackupConnectionStatus.readyToSync});
+        _lastSyncedAtByYear = null;
+        _lastDbUpdatedAtByYear = null;
+      } else if (result.error != null) {
+        AppLogger.d('Dropbox sign-in failed: ${result.error!.message}');
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(result.error!.message)),
+          );
         }
       }
       notifyListeners();

--- a/lib/views/backup_services/backups/show/show_backup_content.dart
+++ b/lib/views/backup_services/backups/show/show_backup_content.dart
@@ -27,7 +27,7 @@ class _ShowBackupContent extends StatelessWidget {
                   Text(
                     [
                       backup.fileInfo.device.model,
-                      sizeInKB,
+                      ?sizeInKB,
                     ].join(" - "),
                     style: TextTheme.of(context).titleSmall,
                   ),

--- a/lib/views/backup_services/show/show_backup_service_view_model.dart
+++ b/lib/views/backup_services/show/show_backup_service_view_model.dart
@@ -202,6 +202,13 @@ class ShowBackupServiceViewModel extends ChangeNotifier with DisposeAwareMixin {
         future: () => backupProvider.recheckAndSync(services: [service], context: context),
       );
       await load();
+    } else if (serviceType == BackupServiceType.dropbox) {
+      // Dropbox's revoked-grant fix is the same interactive OAuth2 flow as a
+      // fresh sign-in (there's no separate "re-request scope" concept the
+      // way Drive has) — signIn() re-runs the PKCE flow and persists the new
+      // tokens itself.
+      await backupProvider.signIn(context, serviceType);
+      await load();
     } else {
       await backupProvider.requestScope(context, serviceType);
       await load();

--- a/lib/views/import_export/import_export_view_model.dart
+++ b/lib/views/import_export/import_export_view_model.dart
@@ -265,7 +265,7 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
     if (result == null) return;
 
     // Share/save the text file
-    if (Platform.isIOS) {
+    if (Platform.isIOS || Platform.isMacOS) {
       RenderBox? box = context.findRenderObject() as RenderBox?;
       await SharePlus.instance.share(
         ShareParams(
@@ -309,7 +309,7 @@ class ImportExportViewModel extends ChangeNotifier with DisposeAwareMixin {
     );
 
     if (backup == null || !context.mounted) return;
-    if (Platform.isIOS) {
+    if (Platform.isIOS || Platform.isMacOS) {
       final file = File("${SupportDirectoryPath.backups.directoryPath}/$exportFileName");
 
       await file.create(recursive: true);

--- a/lib/views/storage_management/storage_management_content.dart
+++ b/lib/views/storage_management/storage_management_content.dart
@@ -128,12 +128,12 @@ class _StorageManagementContent extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SpSectionTitle(title: tr('page.storage_management.section.cloud_storage')),
-        for (final entry in viewModel.cloudQuotas.entries) _buildCloudTile(context, entry.key, entry.value),
+        for (final entry in viewModel.cloudQuotas.entries) ?_buildCloudTile(context, entry.key, entry.value),
       ],
     );
   }
 
-  Widget _buildCloudTile(
+  Widget? _buildCloudTile(
     BuildContext context,
     BackupServiceType serviceType,
     CloudStorageQuotaObject? quota,
@@ -142,11 +142,7 @@ class _StorageManagementContent extends StatelessWidget {
     final email = provider.currentGoogleUser?.email;
 
     if (quota == null) {
-      return ListTile(
-        leading: Icon(serviceType.icon),
-        title: Text(serviceType.displayName),
-        subtitle: const Text('N/A'),
-      );
+      return null;
     }
 
     final appUsageBytes = quota.appUsageInBytes;

--- a/lib/widgets/sp_icons.dart
+++ b/lib/widgets/sp_icons.dart
@@ -36,6 +36,8 @@ class SpIcons {
   // Self-hosted, so a generic server icon rather than a Nextcloud brand mark.
   static const IconData nextcloud = MdiIcons.server;
   static const IconData icloud = Icons.cloud;
+  // ignore: deprecated_member_use, brand icon deprecated upstream by MDI (trademark), no replacement
+  static const IconData dropbox = MdiIcons.dropbox;
   static const IconData cloudDone = Icons.cloud_done_outlined;
   static const IconData mediaSync = kIsCupertino
       ? CupertinoIcons.antenna_radiowaves_left_right

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <desktop_webview_window/desktop_webview_window_plugin.h>
 #include <dynamic_color/dynamic_color_plugin.h>
 #include <emoji_picker_flutter/emoji_picker_flutter_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
@@ -15,8 +16,12 @@
 #include <record_linux/record_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <volume_controller/volume_controller_plugin.h>
+#include <window_to_front/window_to_front_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) desktop_webview_window_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopWebviewWindowPlugin");
+  desktop_webview_window_plugin_register_with_registrar(desktop_webview_window_registrar);
   g_autoptr(FlPluginRegistrar) dynamic_color_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "DynamicColorPlugin");
   dynamic_color_plugin_register_with_registrar(dynamic_color_registrar);
@@ -44,4 +49,7 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) volume_controller_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "VolumeControllerPlugin");
   volume_controller_plugin_register_with_registrar(volume_controller_registrar);
+  g_autoptr(FlPluginRegistrar) window_to_front_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowToFrontPlugin");
+  window_to_front_plugin_register_with_registrar(window_to_front_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_webview_window
   dynamic_color
   emoji_picker_flutter
   file_selector_linux
@@ -12,6 +13,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   record_linux
   url_launcher_linux
   volume_controller
+  window_to_front
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,6 +9,7 @@ import audio_service
 import audio_session
 import cloud_firestore
 import connectivity_plus
+import desktop_webview_window
 import device_info_plus
 import dynamic_color
 import emoji_picker_flutter
@@ -20,6 +21,7 @@ import firebase_crashlytics
 import flutter_local_notifications
 import flutter_secure_storage_darwin
 import flutter_timezone
+import flutter_web_auth_2
 import geocoding_darwin
 import geolocator_apple
 import google_sign_in_ios
@@ -39,12 +41,14 @@ import url_launcher_macos
 import video_compressor_plus
 import video_player_avfoundation
 import volume_controller
+import window_to_front
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  DesktopWebviewWindowPlugin.register(with: registry.registrar(forPlugin: "DesktopWebviewWindowPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   DynamicColorPlugin.register(with: registry.registrar(forPlugin: "DynamicColorPlugin"))
   EmojiPickerFlutterPlugin.register(with: registry.registrar(forPlugin: "EmojiPickerFlutterPlugin"))
@@ -56,6 +60,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
+  FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   GeocodingDarwinPlugin.register(with: registry.registrar(forPlugin: "GeocodingDarwinPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
@@ -75,4 +80,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   VideoCompressorPlusPlugin.register(with: registry.registrar(forPlugin: "VideoCompressorPlusPlugin"))
   VideoPlayerPlugin.register(with: registry.registrar(forPlugin: "VideoPlayerPlugin"))
   VolumeControllerPlugin.register(with: registry.registrar(forPlugin: "VolumeControllerPlugin"))
+  WindowToFrontPlugin.register(with: registry.registrar(forPlugin: "WindowToFrontPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,7 +337,7 @@ packages:
     source: hosted
     version: "0.3.5+5"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
@@ -424,6 +424,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.15"
+  desktop_webview_window:
+    dependency: transitive
+    description:
+      name: desktop_webview_window
+      sha256: b6fdae2cbf9571879b1761c12f27facaf82e22d0bdc74d049907c2a09a432957
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -1008,6 +1016,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
+  flutter_web_auth_2:
+    dependency: "direct main"
+    description:
+      name: flutter_web_auth_2
+      sha256: a7655829251ee63aae64a748f8512f36670d8eba4657b0055cdf5ef304a9d164
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
+  flutter_web_auth_2_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_web_auth_2_platform_interface
+      sha256: ba0fbba55bffb47242025f96852ad1ffba34bc451568f56ef36e613612baffab
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -2610,6 +2634,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  window_to_front:
+    dependency: transitive
+    description:
+      name: window_to_front
+      sha256: "14fad8984db4415e2eeb30b04bb77140b180e260d6cb66b26de126a8657a9241"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   windows_file_picker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   cloud_firestore: ^6.5.0
   connectivity_plus: ^7.0.0
   copy_with_extension: ^17.0.0
+  crypto: ^3.0.7
   cupertino_icons: 1.0.9
   dart_quill_delta: 10.8.3
   device_info_plus: ^13.2.0
@@ -43,6 +44,10 @@ dependencies:
   flutter_slidable: 4.0.3
   flutter_staggered_grid_view: 0.7.0
   flutter_svg: ^2.3.0
+  # OAuth2 PKCE browser hand-off for Dropbox — system browser / OS auth
+  # session per platform (ASWebAuthenticationSession, Custom Tabs, loopback
+  # on Linux), never an embedded WebView. See DropboxOAuthService.
+  flutter_web_auth_2: ^5.1.0
   fuzzy: 0.5.1
   geocoding: ^5.0.0
   geolocator: ^14.0.2

--- a/test/core/objects/cloud_file_object_test.dart
+++ b/test/core/objects/cloud_file_object_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:storypad/core/objects/cloud_file_object.dart';
+
+void main() {
+  // Only fromDropbox is covered here — the other factories (fromGoogleDrive,
+  // fromNextcloud, fromICloud) have no existing test coverage either, and
+  // backfilling those is out of scope for this change.
+  group('CloudFileObject.fromDropbox', () {
+    test('parses id, name, size, and timestamps from live FileMetadata', () {
+      final file = CloudFileObject.fromDropbox({
+        '.tag': 'file',
+        'name': 'Backup__3__2026__1234567890__device__id.zip',
+        'id': 'id:abc123',
+        'size': 4096,
+        'client_modified': '2026-01-01T00:00:00Z',
+        'server_modified': '2026-01-02T00:00:00Z',
+      });
+
+      expect(file.id, 'id:abc123');
+      expect(file.fileName, 'Backup__3__2026__1234567890__device__id.zip');
+      expect(file.sizeInBytes, 4096);
+      expect(file.createdAt, DateTime.parse('2026-01-01T00:00:00Z'));
+      expect(file.modifiedAt, DateTime.parse('2026-01-02T00:00:00Z'));
+      expect(file.trashed, isFalse);
+    });
+
+    test('falls back to idOverride for deleted metadata, which carries no id field', () {
+      final file = CloudFileObject.fromDropbox(
+        {'.tag': 'deleted', 'name': 'old_backup.zip'},
+        trashed: true,
+        idOverride: 'id:the-original-query-key',
+      );
+
+      expect(file.id, 'id:the-original-query-key');
+      expect(file.trashed, isTrue);
+      expect(file.sizeInBytes, isNull);
+    });
+
+    test('defaults trashed to false when not specified', () {
+      final file = CloudFileObject.fromDropbox({'name': 'a.zip', 'id': 'id:1'});
+      expect(file.trashed, isFalse);
+    });
+  });
+}

--- a/test/core/repositories/backup_repository_test.dart
+++ b/test/core/repositories/backup_repository_test.dart
@@ -9,6 +9,7 @@ import 'package:storypad/core/objects/nextcloud_user_object.dart';
 import 'package:storypad/core/repositories/backup_repository.dart';
 import 'package:storypad/core/services/backups/backup_cloud_service.dart';
 import 'package:storypad/core/services/backups/backup_service_type.dart';
+import 'package:storypad/core/services/backups/dropbox_cloud_service.dart';
 import 'package:storypad/core/services/backups/nextcloud_cloud_service.dart';
 import 'package:storypad/core/services/backups/sync_steps/backup_images_uploader_service.dart';
 import 'package:storypad/core/services/backups/sync_steps/backup_importer_service.dart';
@@ -32,6 +33,10 @@ void main() {
     final messenger = BackupSyncMessenger();
     return BackupRepository(
       icloudService: icloudService,
+      // Not exercised by these checkConnection tests — a plain, never-signed-in
+      // instance is inert (excluded from checkableServices) without needing a
+      // dedicated fake, unlike Nextcloud/iCloud which these tests do assert on.
+      dropboxService: DropboxCloudService(),
       restoreService: RestoreBackupService(),
       messenger: messenger,
       step1ImagesUploader: BackupImagesUploaderService(messenger: messenger),

--- a/test/core/services/dropbox_cloud_service_test.dart
+++ b/test/core/services/dropbox_cloud_service_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:storypad/core/objects/backup_exceptions/backup_exception.dart';
+import 'package:storypad/core/services/backups/backup_service_type.dart';
+import 'package:storypad/core/services/backups/dropbox_cloud_service.dart';
+
+void main() {
+  group('DropboxCloudService', () {
+    late DropboxCloudService service;
+
+    setUp(() {
+      service = DropboxCloudService();
+    });
+
+    test('serviceType is dropbox', () {
+      expect(service.serviceType, BackupServiceType.dropbox);
+    });
+
+    test('hasCompression is true (shared with every provider)', () {
+      expect(service.hasCompression, isTrue);
+    });
+
+    test('is not signed in before initialize/signIn', () {
+      expect(service.isSignedIn, isFalse);
+      expect(service.currentUser, isNull);
+    });
+
+    test('canAccessRequestedScopes/requestScope are false when signed out', () async {
+      expect(await service.canAccessRequestedScopes(), isFalse);
+      expect(await service.requestScope(), isFalse);
+    });
+
+    test('reauthenticateIfNeeded throws signInRequired when never connected', () async {
+      await expectLater(
+        service.reauthenticateIfNeeded(),
+        throwsA(
+          isA<AuthException>().having((e) => e.type, 'type', AuthExceptionType.signInRequired),
+        ),
+      );
+    });
+
+    test('file operations throw signInRequired when not connected', () async {
+      await expectLater(
+        service.deleteFile('id:whatever'),
+        throwsA(
+          isA<AuthException>().having((e) => e.type, 'type', AuthExceptionType.signInRequired),
+        ),
+      );
+    });
+  });
+}

--- a/test/core/services/dropbox_oauth_service_test.dart
+++ b/test/core/services/dropbox_oauth_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:storypad/core/services/backups/dropbox_oauth_service.dart';
+
+void main() {
+  // Pure over its input (no network/browser), so it's testable directly —
+  // the one thing standing between a fresh sign-in and Dropbox rejecting the
+  // whole OAuth flow with an opaque "bad request" if it's ever wrong.
+  group('DropboxOAuthService.codeChallengeFor', () {
+    test('matches the official RFC 7636 Appendix B.1 test vector', () {
+      // https://datatracker.ietf.org/doc/html/rfc7636#appendix-B
+      const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+      const expectedChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+      expect(DropboxOAuthService.codeChallengeFor(verifier), expectedChallenge);
+    });
+
+    test('is deterministic for the same verifier', () {
+      const verifier = 'some-random-code-verifier-value-1234567890';
+      expect(
+        DropboxOAuthService.codeChallengeFor(verifier),
+        DropboxOAuthService.codeChallengeFor(verifier),
+      );
+    });
+
+    test('differs for different verifiers', () {
+      expect(
+        DropboxOAuthService.codeChallengeFor('verifier-a'),
+        isNot(DropboxOAuthService.codeChallengeFor('verifier-b')),
+      );
+    });
+
+    test('never contains base64 padding or non-URL-safe characters', () {
+      final challenge = DropboxOAuthService.codeChallengeFor('any-verifier-value');
+      expect(challenge, isNot(contains('=')));
+      expect(challenge, isNot(contains('+')));
+      expect(challenge, isNot(contains('/')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds Dropbox as a fourth backup/sync provider (`DropboxCloudService`), implementing `BackupCloudService` alongside Drive/Nextcloud/iCloud — works on every platform this app targets (iOS, Android, macOS, Linux), with no platform gate or disabled stub needed since it's pure REST.
- Fully client-side, no backend: auth is OAuth2's **PKCE flow for public/native clients** (`DropboxOAuthService`, via `flutter_web_auth_2` for the system-browser/OS-auth-session hand-off) — no client secret anywhere, matching Nextcloud's already-client-side design.
- App-folder scope (sandboxed to `Apps/StoryPad`), native Dropbox trash (`files/delete_v2`/`files/restore`) instead of manual `.trash/` emulation, and real Dropbox file IDs (`id:xxxx`) used directly as `CloudFileObject.id`.
- OAuth redirect is a plain per-flavor deep link (`storypad://`, `spooky://`, `spookycommunity://`, via a `dropboxCallbackScheme` Gradle manifest placeholder per Android flavor) — deliberately not a hosted HTTPS redirect domain, since PKCE already defeats the code-interception attack that pattern exists to prevent.
- `DROPBOX_APP_KEY` dart-define wired up (`kDropboxAppKey`); actual key value added separately in `private_keys/`.

<img width="394" height="421" alt="image" src="https://github.com/user-attachments/assets/5ddc3c42-8aec-4b79-bef6-ec70624d507f" />

## Test plan
- [x] `flutter analyze` — clean
- [x] `flutter test` — full suite passes (950 tests)
- [x] Manually verified the OAuth redirect against a real Dropbox app registration during development
- [ ] On-device verification across iOS/Android/macOS/Linux (real Dropbox app credentials required)