### PR TITLE
Allow multi-tag search filtering with OR matching

### DIFF
--- a/lib/core/databases/adapters/objectbox/stories_box.dart
+++ b/lib/core/databases/adapters/objectbox/stories_box.dart
@@ -651,10 +651,13 @@ class StoriesBox extends BaseBox<StoryObjectBox, StoryDbModel> {
     if (tag != null) conditions = conditions.and(StoryObjectBox_.tags.containsElement(tag.toString()));
 
     if (tags != null && tags.isNotEmpty) {
-      // AND logic: story must have ALL specified tags.
-      for (final t in tags) {
-        conditions = conditions.and(StoryObjectBox_.tags.containsElement(t.toString()));
+      // OR logic: story must have ANY of the specified tags (this group is then AND-ed
+      // with the rest of the filters below).
+      Condition<StoryObjectBox> tagsCondition = StoryObjectBox_.tags.containsElement(tags.first.toString());
+      for (final t in tags.skip(1)) {
+        tagsCondition = tagsCondition.or(StoryObjectBox_.tags.containsElement(t.toString()));
       }
+      conditions = conditions.and(tagsCondition);
     }
 
     if (galleryTemplateId != null) {

--- a/lib/views/search/filter/search_filter_view_model.dart
+++ b/lib/views/search/filter/search_filter_view_model.dart
@@ -111,27 +111,10 @@ class SearchFilterViewModel extends ChangeNotifier with DisposeAwareMixin {
   bool tagSelected(TagDbModel tag) => searchFilter.tagIds.contains(tag.id);
 
   void toggleTag(TagDbModel tag) {
-    final category = tagsByCategory?.keys.firstWhere((c) => c?.id == tag.categoryId, orElse: () => null);
+    // Selected tags are OR-ed together (a story matches if it has ANY of them), so
+    // there's no "impossible combination" risk — every category can multi-select freely.
     Set<int> newTagIds = {...searchFilter.tagIds};
-
-    if (category?.multiSelect == true) {
-      // Multi-select category (e.g. People): just toggle this tag on/off.
-      if (!newTagIds.remove(tag.id)) newTagIds.add(tag.id);
-    } else {
-      // Single-select per category: remove any other selected tag in the same category first.
-      final categoryTags =
-          tagsByCategory?.entries
-              .where((e) => e.key?.id == tag.categoryId)
-              .expand((e) => e.value)
-              .map((t) => t.id)
-              .toSet() ??
-          {};
-
-      newTagIds.removeAll(categoryTags);
-
-      // Toggle: if tag was already selected it was removed above → do not re-add.
-      if (!searchFilter.tagIds.contains(tag.id)) newTagIds.add(tag.id);
-    }
+    if (!newTagIds.remove(tag.id)) newTagIds.add(tag.id);
 
     searchFilter = searchFilter.copyWith(tagIds: newTagIds);
     notifyListeners();

--- a/lib/views/search/search_content.dart
+++ b/lib/views/search/search_content.dart
@@ -54,13 +54,15 @@ class _SearchContent extends StatelessWidget {
           ),
           IconButton(
             tooltip: tr("page.search_filter.title"),
-            icon: const Icon(SpIcons.tune),
+            icon: viewModel.hasHiddenTagFilters
+                ? Badge(backgroundColor: ColorScheme.of(context).primary, child: const Icon(SpIcons.tune))
+                : const Icon(SpIcons.tune),
             onPressed: () => viewModel.goToFilterPage(context),
           ),
           if (CupertinoSheetRoute.hasParentSheet(context))
             CloseButton(onPressed: () => CupertinoSheetRoute.popSheet(context)),
         ],
-        bottom: visibleTags.isNotEmpty == true
+        bottom: visibleTags.isNotEmpty == true && viewModel.showTagFilterBar
             ? PreferredSize(
                 preferredSize: const Size.fromHeight(34.0 + 12.0),
                 child: Column(

--- a/lib/views/search/search_view_model.dart
+++ b/lib/views/search/search_view_model.dart
@@ -100,6 +100,24 @@ class SearchViewModel extends ChangeNotifier with DisposeAwareMixin, DebounchedC
     SearchFilterStorage().writeObject(searchFilter!);
   }
 
+  // The quick-filter bar only ever represents a single active tag (tapping a chip
+  // replaces the selection), so once the filter page applies more than one tag — or a
+  // category tag (People, Feeling, Weather, Activity) that has no chip here at all — the
+  // bar can no longer represent the selection and is hidden; surface a badge instead of
+  // leaving the filter silently invisible.
+  bool get hasHiddenTagFilters {
+    if (searchFilter == null) return false;
+    if (searchFilter!.tagIds.length > 1) return true;
+
+    final visibleTagIds = tags?.map((tag) => tag.id).toSet() ?? {};
+    return searchFilter!.tagIds.any((id) => !visibleTagIds.contains(id));
+  }
+
+  // Bar shows a single selected chip at most; with 2+ tags applied (from the filter
+  // page) no single chip can represent the selection, so hide it instead of showing a
+  // misleading "no tag selected" bar.
+  bool get showTagFilterBar => (searchFilter?.tagIds.length ?? 0) <= 1;
+
   bool tagSelected(TagDbModel tag) =>
       searchFilter?.tagIds.contains(tag.id) == true || (tag.id == 0 && searchFilter?.tagIds.isEmpty == true);
 


### PR DESCRIPTION
## Summary
- This is a requested feature from user emails: search's filter page only ever let people select one tag per category (aside from People/Activity), so combining tags to broaden a search wasn't possible.
- Filter page now lets every tag category multi-select; selecting multiple tags matches stories that have **any** of them (OR), not all.
- Search page's quick-filter bar still shows/replaces a single tag on tap (keeps that quick-filter simple), and hides itself — replaced by a badge on the filter icon — once a broader multi-tag filter is applied from the filter page, so the applied filter is never silently invisible.

## Test plan
- [x] Open Search → filter → select two tags from the same category (e.g. two Feeling tags) → apply → confirm results include stories with either tag, not just stories with both.
- [x] Confirm the quick-filter bar on the search page disappears when 2+ tags are applied, and the filter (tune) icon shows a dot.
- [x] Confirm selecting a People or Feeling tag (not shown in the quick-filter bar) still shows the badge on the tune icon.
- [x] Confirm tapping a chip in the search page's quick-filter bar still replaces the selection with just that one tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oqo1VxoMh5BxU6Xtp6b3v