### PR TITLE
Add demo images for multi-cloud-sync paywall feature

### DIFF
--- a/lib/gen/storage_hash_map.dart
+++ b/lib/gen/storage_hash_map.dart
@@ -49,6 +49,12 @@ const Map<String, String> kStorageHashMap = {
       "/feature_demos/markdown_export/markdown_export_4__3060x2400-1c117701d163cdc5c64e8c2df325c56c.jpg",
   "/feature_demos/markdown_export/markdown_export_5__2070x2400.jpg":
       "/feature_demos/markdown_export/markdown_export_5__2070x2400-7f115e535d61987e2d508562234bb6d2.jpg",
+  "/feature_demos/multi_cloud_sync/multi_cloud_sync_1__1080x2400.jpg":
+      "/feature_demos/multi_cloud_sync/multi_cloud_sync_1__1080x2400-a1ef92951410e90b3d32da64f7e63359.jpg",
+  "/feature_demos/multi_cloud_sync/multi_cloud_sync_2__1080x2400.jpg":
+      "/feature_demos/multi_cloud_sync/multi_cloud_sync_2__1080x2400-677f37aff14a2fc9d4e35678cec1aaff.jpg",
+  "/feature_demos/multi_cloud_sync/multi_cloud_sync_3__1080x2400.jpg":
+      "/feature_demos/multi_cloud_sync/multi_cloud_sync_3__1080x2400-2c03d9539ace754639a2f76fc57ba1ff.jpg",
   "/feature_demos/period_calendar/period_calendar_1__1080x2400.jpg":
       "/feature_demos/period_calendar/period_calendar_1__1080x2400-d8a71e56b7d98c5a5d2aad473309757f.jpg",
   "/feature_demos/period_calendar/period_calendar_2__1080x2400.jpg":

--- a/lib/views/paywall/paywall_view_model.dart
+++ b/lib/views/paywall/paywall_view_model.dart
@@ -109,6 +109,19 @@ class PaywallViewModel extends ChangeNotifier with DisposeAwareMixin {
         onOpen: (BuildContext context) => StatsRoute(initialRange: StatsRange.year(DateTime.now())).push(context),
       ),
       PaywallFeatureObject(
+        type: PaywallFeature.multi_cloud_sync,
+        title: tr('paywall_features.multi_cloud_sync.title'),
+        subtitle: tr('paywall_features.multi_cloud_sync.subtitle'),
+        iconData: SpIcons.nextcloud,
+        weekdayColor: 6,
+        demoImagePaths: [
+          '/feature_demos/multi_cloud_sync/multi_cloud_sync_1__1080x2400.jpg',
+          '/feature_demos/multi_cloud_sync/multi_cloud_sync_2__1080x2400.jpg',
+          '/feature_demos/multi_cloud_sync/multi_cloud_sync_3__1080x2400.jpg',
+        ],
+        onOpen: (BuildContext context) => const DataBackupRoute().push(context),
+      ),
+      PaywallFeatureObject(
         type: PaywallFeature.markdown_export,
         title: tr('paywall_features.markdown_export.title'),
         subtitle: tr('paywall_features.markdown_export.subtitle'),
@@ -122,15 +135,6 @@ class PaywallViewModel extends ChangeNotifier with DisposeAwareMixin {
           '/feature_demos/markdown_export/markdown_export_5__2070x2400.jpg',
         ],
         onOpen: (BuildContext context) => const ImportExportRoute(initialExportOption: .markdown).push(context),
-      ),
-      PaywallFeatureObject(
-        type: PaywallFeature.multi_cloud_sync,
-        title: tr('paywall_features.multi_cloud_sync.title'),
-        subtitle: tr('paywall_features.multi_cloud_sync.subtitle'),
-        iconData: SpIcons.nextcloud,
-        weekdayColor: 6,
-        demoImagePaths: [],
-        onOpen: (BuildContext context) => const DataBackupRoute().push(context),
       ),
     ];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: storypad
-version: 2.33.1+817
+version: 2.33.1+819
 publish_to: none
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## Summary
- Wires up the 3 `multi_cloud_sync` demo images (cross-platform overview, popular cloud providers, self-host) that were already published to the CDN but not yet referenced.
- Moves the `multi_cloud_sync` `PaywallFeatureObject` entry earlier in the list (before `markdown_export`) alongside the new `demoImagePaths`.

## Test plan
- [x] Open the paywall, select "More Cloud Options", confirm the 3 demo images load in the carousel and open in the full-screen viewer on tap.

<img width="414" height="887" alt="image" src="https://github.com/user-attachments/assets/64ffe115-71df-47a0-bf70-760bdcf123ba" />