### PR TITLE
Avoid full-list reloads on archive/bin/put-back and fix stuck snackbar

### DIFF
--- a/lib/core/services/messenger_service.dart
+++ b/lib/core/services/messenger_service.dart
@@ -38,7 +38,8 @@ class MessengerService {
     Color? background = success ? null : Theme.of(context).colorScheme.error;
     double? width = MediaQuery.of(context).size.width > 1000 ? 400.0 : null;
 
-    scaffoldFeatureController = state?.showSnackBar(
+    final messengerState = state;
+    scaffoldFeatureController = messengerState?.showSnackBar(
       SnackBar(
         duration: duration,
         width: width,
@@ -58,10 +59,16 @@ class MessengerService {
       ),
     );
 
-    // When we our own custom ScaffoldMessager on end drawer instead of using Scaffold. SnackBar is not auto closed.
-    // Manually close in this case.
+    // When we use our own custom ScaffoldMessenger on the end drawer instead of a
+    // Scaffold's, the SnackBar is not auto closed. Manually close in this case.
+    //
+    // Check the ScaffoldMessengerState's own `mounted` flag rather than the calling
+    // `context`'s — the story/screen that triggered this snackbar (e.g. an archived
+    // tile) can be removed from the tree well before `duration` elapses, which would
+    // skip this cleanup and leave the SnackBar stuck forever even though the
+    // ScaffoldMessenger showing it is still very much alive.
     Future.delayed(duration + const Duration(milliseconds: 100)).then((_) {
-      if (context.mounted) clearSnackBars();
+      if (messengerState?.mounted == true) messengerState!.clearSnackBars();
     });
 
     return scaffoldFeatureController;

--- a/lib/views/archives/archives_content.dart
+++ b/lib/views/archives/archives_content.dart
@@ -49,8 +49,9 @@ class _ArchivesContent extends StatelessWidget {
       return TabBarView(
         children: years.map((year) {
           return SpStoryList.withQuery(
-            key: ValueKey('${viewModel.editedKey}_$year'),
+            key: ValueKey(year),
             viewOnly: true,
+            watch: viewModel,
             filter: SearchFilterObject(
               years: {year},
               types: {viewModel.type},

--- a/lib/views/archives/archives_view_model.dart
+++ b/lib/views/archives/archives_view_model.dart
@@ -16,7 +16,6 @@ class ArchivesViewModel extends ChangeNotifier with DisposeAwareMixin {
     load();
   }
 
-  int editedKey = 0;
   late PathType type = params.pathType;
 
   List<int>? years;
@@ -34,10 +33,10 @@ class ArchivesViewModel extends ChangeNotifier with DisposeAwareMixin {
     notifyListeners();
   }
 
-  void refreshList() {
-    editedKey++;
-    load();
-  }
+  /// Refreshes the year tabs and, via [ArchivesViewModel] being passed as
+  /// `watch` to each tab's [SpStoryListWithQuery], silently reloads each
+  /// tab's story list too — without remounting it (no loading-spinner flash).
+  Future<void> refreshList() => load();
 
   Future<void> onPopInvokedWithResult(bool didPop, dynamic result, BuildContext context) async {
     if (didPop) return;

--- a/lib/views/calendar/mood/mood_calendar_content.dart
+++ b/lib/views/calendar/mood/mood_calendar_content.dart
@@ -129,8 +129,9 @@ class _CalendarStoriesContent extends StatelessWidget {
         // Index 0 shows all stories for the month
         if (index == 0) {
           return SpStoryList.withQuery(
-            key: ValueKey(jsonEncode(viewModel.searchFilter.toDatabaseFilter()) + viewModel.editedKey.toString()),
+            key: ValueKey(jsonEncode(viewModel.searchFilter.toDatabaseFilter())),
             disableMultiEdit: true,
+            watch: viewModel,
             filter: viewModel.searchFilter,
           );
         }
@@ -147,8 +148,9 @@ class _CalendarStoriesContent extends StatelessWidget {
         );
 
         return SpStoryList.withQuery(
-          key: ValueKey(jsonEncode(filter.toDatabaseFilter()) + viewModel.editedKey.toString()),
+          key: ValueKey(jsonEncode(filter.toDatabaseFilter())),
           disableMultiEdit: true,
+          watch: viewModel,
           filter: SearchFilterObject(
             years: {viewModel.year},
             month: viewModel.month,

--- a/lib/views/calendar/mood/mood_calendar_view_model.dart
+++ b/lib/views/calendar/mood/mood_calendar_view_model.dart
@@ -75,9 +75,10 @@ class MoodCalendarViewModel extends ChangeNotifier with DisposeAwareMixin, Debou
   late int month = params.monthYearNotifier.value.month;
   late int year = params.monthYearNotifier.value.year;
 
-  int editedKey = 0;
+  /// [SpStoryList.withQuery] is passed this view model as `watch`, so calling
+  /// this silently reloads the visible story list — without remounting it
+  /// (no loading-spinner flash).
   void refreshList() {
-    editedKey++;
     notifyListeners();
   }
 

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -80,6 +80,21 @@ class HomeView extends StatelessWidget {
     return _homeContext?.read<HomeViewModel>().reload(debugSource: debugSource);
   }
 
+  /// Applies a single story change locally, without a full DB refetch.
+  ///
+  /// Unlike the per-tile [SpStoryListenerBuilder] callbacks, this doesn't
+  /// require the story's tile to currently be mounted in Home — so it's
+  /// safe to call for stories acted on from another screen (e.g. bulk
+  /// archive/bin/put-back from Archives) that may not be built yet.
+  static void applyStoryReloaded(StoryDbModel story) {
+    _homeContext?.read<HomeViewModel>().onAStoryReloaded(story);
+  }
+
+  /// See [applyStoryReloaded]; for permanent deletions.
+  static void applyStoryDeleted(StoryDbModel story) {
+    _homeContext?.read<HomeViewModel>().onAStoryDeleted(story);
+  }
+
   static void scrollToTop() {
     _homeContext!.read<HomeViewModel>().scrollInfo.scrollToTop();
   }

--- a/lib/views/home/home_view_model.dart
+++ b/lib/views/home/home_view_model.dart
@@ -551,7 +551,10 @@ class HomeViewModel extends ChangeNotifier with DisposeAwareMixin {
   }
 
   void onAStoryReloaded(StoryDbModel updatedStory) {
-    if (updatedStory.type != PathType.docs) {
+    if (updatedStory.type != PathType.docs || updatedStory.year != year) {
+      // Either archived/binned, or moved back into a year Home isn't
+      // currently showing — in both cases it doesn't belong in the
+      // current view, so just drop it if present rather than inserting it.
       setStories(stories?.removeElement(updatedStory), pinnedStories?.removeElement(updatedStory));
       AppLogger.d('🚧 Removed ${updatedStory.id}:${updatedStory.type.name} by $runtimeType#onAStoryReloaded');
     } else {

--- a/lib/views/tags/show/show_tag_content.dart
+++ b/lib/views/tags/show/show_tag_content.dart
@@ -63,8 +63,9 @@ class _ShowTagContent extends StatelessWidget {
     return TabBarView(
       children: years.map((year) {
         return SpStoryList.withQuery(
-          key: ValueKey('${viewModel.editedKey}_$year'),
+          key: ValueKey(year),
           viewOnly: viewModel.params.storyViewOnly,
+          watch: viewModel,
           filter: viewModel.filter.copyWith(years: {year}),
         );
       }).toList(),
@@ -100,12 +101,18 @@ class _ShowTagContent extends StatelessWidget {
       buttons: [
         OutlinedButton(
           child: Text("${tr("button.archive")} (${state.selectedStories.length})"),
-          onPressed: () => state.archiveAll(context),
+          onPressed: () async {
+            await state.archiveAll(context);
+            viewModel.refreshList();
+          },
         ),
         FilledButton(
           style: FilledButton.styleFrom(backgroundColor: ColorScheme.of(context).error),
           child: Text("${tr("button.move_to_bin")} (${state.selectedStories.length})"),
-          onPressed: () => state.moveToBinAll(context),
+          onPressed: () async {
+            await state.moveToBinAll(context);
+            viewModel.refreshList();
+          },
         ),
       ],
     );

--- a/lib/views/tags/show/show_tag_view_model.dart
+++ b/lib/views/tags/show/show_tag_view_model.dart
@@ -27,7 +27,6 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
   late TagDbModel _tag;
   TagDbModel get tag => _tag;
 
-  int editedKey = 0;
   List<int>? years;
 
   late final initialTune = SearchFilterObject(years: {}, types: {}, tagIds: {tag.id}, assetId: null);
@@ -40,10 +39,10 @@ class ShowTagViewModel extends ChangeNotifier with DisposeAwareMixin {
     notifyListeners();
   }
 
-  void refreshList() {
-    editedKey++;
-    load();
-  }
+  /// See [ArchivesViewModel.refreshList] — refreshes the year tabs and,
+  /// since [ShowTagViewModel] is passed as `watch` to each tab's
+  /// [SpStoryListWithQuery], silently reloads each tab's story list too.
+  Future<void> refreshList() => load();
 
   late SearchFilterObject filter = SearchFilterObject(
     years: {},

--- a/lib/views/throwback/throwback_content.dart
+++ b/lib/views/throwback/throwback_content.dart
@@ -16,8 +16,8 @@ class _ThrowbackContent extends StatelessWidget {
         onPressed: () => viewModel.goToNewPage(context),
       ),
       body: SpStoryList.withQuery(
-        key: ValueKey(viewModel.editedKey),
         disableMultiEdit: true,
+        watch: viewModel,
         filter: viewModel.filter,
       ),
     );

--- a/lib/views/throwback/throwback_view_model.dart
+++ b/lib/views/throwback/throwback_view_model.dart
@@ -16,10 +16,10 @@ class ThrowbackViewModel extends ChangeNotifier with DisposeAwareMixin {
   late final int month = params.month;
   late final int day = params.day;
 
-  int editedKey = 0;
-
+  /// [SpStoryList.withQuery] is passed this view model as `watch`, so calling
+  /// this silently reloads the visible story list — without remounting it
+  /// (no loading-spinner flash).
   void refreshList() {
-    editedKey++;
     notifyListeners();
   }
 
@@ -41,8 +41,7 @@ class ThrowbackViewModel extends ChangeNotifier with DisposeAwareMixin {
       initialDay: day,
     ).push(context);
 
-    editedKey += 1;
-    notifyListeners();
+    refreshList();
 
     Future.delayed(const Duration(seconds: 1)).then((_) {
       HomeView.reload(debugSource: '$runtimeType#goToNewPage');

--- a/lib/widgets/story_list/local_widgets/story_tile_actions.dart
+++ b/lib/widgets/story_list/local_widgets/story_tile_actions.dart
@@ -105,7 +105,7 @@ class StoryTileActions {
         await SpStoryListWithQuery.of(storyListReloaderContext!)?.load(debugSource: '$runtimeType#undoMoveToBin');
       }
 
-      return reloadHome('$runtimeType#undoMoveToBin');
+      HomeView.applyStoryReloaded(updatedStory);
     }
 
     if (context.mounted) {
@@ -150,7 +150,7 @@ class StoryTileActions {
                 story: updatedStory,
               );
 
-              return reloadHome('$runtimeType#archive');
+              HomeView.applyStoryReloaded(updatedStory);
             },
           );
         },
@@ -165,7 +165,7 @@ class StoryTileActions {
     StoryDbModel? updatedStory = await originalStory.putBack();
     if (updatedStory == null) return false;
 
-    await reloadHome('$runtimeType#putBack');
+    HomeView.applyStoryReloaded(updatedStory);
 
     AnalyticsService.instance.logPutStoryBack(
       story: updatedStory,
@@ -182,8 +182,9 @@ class StoryTileActions {
 
         if (storyListReloaderContext != null && storyListReloaderContext!.mounted) {
           await SpStoryListWithQuery.of(storyListReloaderContext!)?.load(debugSource: '$runtimeType#undoPutBack');
-          await reloadHome('$runtimeType#undoPutBack');
         }
+
+        HomeView.applyStoryReloaded(updatedStory);
       }
 
       MessengerService.of(storyListReloaderContext!).showSnackBar(

--- a/lib/widgets/story_list/sp_story_list.dart
+++ b/lib/widgets/story_list/sp_story_list.dart
@@ -37,12 +37,14 @@ class SpStoryList extends StatelessWidget {
     SearchFilterObject? filter,
     bool viewOnly = false,
     bool disableMultiEdit = false,
+    Listenable? watch,
   }) {
     return SpStoryListWithQuery(
       key: key,
       filter: filter,
       viewOnly: viewOnly,
       disableMultiEdit: disableMultiEdit,
+      watch: watch,
     );
   }
 

--- a/lib/widgets/story_list/sp_story_list_multi_edit_wrapper_state.dart
+++ b/lib/widgets/story_list/sp_story_list_multi_edit_wrapper_state.dart
@@ -60,9 +60,9 @@ class SpStoryListMultiEditWrapperState extends ChangeNotifier {
           for (int i = 0; i < selectedStories.length; i++) {
             int id = selectedStories.elementAt(i);
             final record = await StoryDbModel.db.find(id);
-            await record?.putBack();
+            final updatedStory = await record?.putBack();
+            if (updatedStory != null) HomeView.applyStoryReloaded(updatedStory);
           }
-          await HomeView.reload(debugSource: '$runtimeType#putBackAll');
         },
       );
 
@@ -89,9 +89,9 @@ class SpStoryListMultiEditWrapperState extends ChangeNotifier {
           for (int i = 0; i < selectedStories.length; i++) {
             int id = selectedStories.elementAt(i);
             final record = await StoryDbModel.db.find(id);
-            await record?.moveToBin();
+            final updatedStory = await record?.moveToBin();
+            if (updatedStory != null) HomeView.applyStoryReloaded(updatedStory);
           }
-          await HomeView.reload(debugSource: '$runtimeType#moveToBinAll');
         },
       );
 
@@ -147,10 +147,9 @@ class SpStoryListMultiEditWrapperState extends ChangeNotifier {
           for (int i = 0; i < selectedStories.length; i++) {
             int id = selectedStories.elementAt(i);
             final record = await StoryDbModel.db.find(id);
-            await record?.archive();
+            final updatedStory = await record?.archive();
+            if (updatedStory != null) HomeView.applyStoryReloaded(updatedStory);
           }
-
-          await HomeView.reload(debugSource: '$runtimeType#archiveAll');
         },
       );
 
@@ -181,7 +180,6 @@ class SpStoryListMultiEditWrapperState extends ChangeNotifier {
             int id = state.selectedStories.elementAt(i);
             await StoryDbModel.db.delete(id);
           }
-          await HomeView.reload(debugSource: '$runtimeType#putBackAll');
         },
       );
 

--- a/lib/widgets/story_list/sp_story_list_with_query.dart
+++ b/lib/widgets/story_list/sp_story_list_with_query.dart
@@ -17,11 +17,19 @@ class SpStoryListWithQuery extends StatefulWidget {
     this.viewOnly = false,
     this.filter,
     this.disableMultiEdit = false,
+    this.watch,
   });
 
   final SearchFilterObject? filter;
   final bool viewOnly;
   final bool disableMultiEdit;
+
+  /// Optional [Listenable] (e.g. a screen's view model) that, when it
+  /// notifies, triggers a silent [SpStoryListWithQueryState.load] — without
+  /// remounting the widget or showing the loading spinner. Lets a screen
+  /// force a refresh (e.g. after a bulk action) without the full-list
+  /// flash a `key` change would cause.
+  final Listenable? watch;
 
   String get uniqueness => jsonEncode(filter?.toDatabaseFilter()) + viewOnly.toString();
 
@@ -85,23 +93,34 @@ class SpStoryListWithQueryState extends State<SpStoryListWithQuery> {
       stories = null;
       load(debugSource: '$runtimeType#didUpdateWidget');
     }
+
+    if (widget.watch != oldWidget.watch) {
+      oldWidget.watch?.removeListener(_watchListener);
+      widget.watch?.addListener(_watchListener);
+    }
   }
 
   @override
   void initState() {
     load(debugSource: '$runtimeType#initState');
     BackupProvider.repoInstance.restoreService.addListener(_restoreServiceListener);
+    widget.watch?.addListener(_watchListener);
     super.initState();
   }
 
   @override
   void dispose() {
     BackupProvider.repoInstance.restoreService.removeListener(_restoreServiceListener);
+    widget.watch?.removeListener(_watchListener);
     super.dispose();
   }
 
   Future<void> _restoreServiceListener() async {
     load(debugSource: '$runtimeType#_restoreServiceListener');
+  }
+
+  Future<void> _watchListener() async {
+    load(debugSource: '$runtimeType#watch');
   }
 
   @override
@@ -153,15 +172,21 @@ class SpStoryListWithQueryState extends State<SpStoryListWithQuery> {
       viewOnly: widget.viewOnly,
       onDeleted: () => load(debugSource: '$runtimeType#onDeleted'),
       onChanged: (updatedStory) {
-        if (widget.filter?.day != null && updatedStory.day != widget.filter!.day) {
-          // If filtering by day and the updated story is no longer on that day,
-          // remove it from the list.
+        final filter = widget.filter;
+        final dayMismatch = filter?.day != null && updatedStory.day != filter!.day;
+        final typeMismatch = filter?.types.isNotEmpty == true && !filter!.types.contains(updatedStory.type);
+        final starredMismatch = filter?.starred != null && updatedStory.starred != filter!.starred;
+        final pinnedMismatch = filter?.pinned != null && updatedStory.pinned != filter!.pinned;
+
+        if (dayMismatch || typeMismatch || starredMismatch || pinnedMismatch) {
+          // The updated story no longer matches this list's filter (e.g. it
+          // was archived/put back/un-starred) — remove it instead of leaving
+          // a stale entry behind until the next manual refresh.
           stories = stories?.removeElement(updatedStory);
-          setState(() {});
         } else {
           stories = stories?.replaceElement(updatedStory);
-          setState(() {});
         }
+        setState(() {});
       },
     );
   }


### PR DESCRIPTION
## Summary
- Archiving, binning, or putting back a story (single or bulk) forced a full DB refetch or a full list remount, causing a visible reload flash. Story lists now apply changes locally via targeted view-model updates instead.
- Year-tabbed lists (Archives, Bin, Tag view, mood calendar, throwback) used to force-remount via a `ValueKey` bump on every refresh (loading spinner flash). They now reload silently through a `watch: Listenable` passed to `SpStoryListWithQuery`.
- Fixed archived/put-back items lingering in Archives/Bin/Tag view until a manual pull-to-refresh — the shared list's `onChanged` handler only checked a `day` filter mismatch, never `types`/`starred`/`pinned`.
- Fixed a snackbar (e.g. archive/unarchive success) getting stuck on screen forever on tablet layouts: `MessengerService`'s manual dismiss fallback checked the *triggering* context's `mounted` flag, but that context (e.g. an archived tile) is often removed from the tree before the fallback fires. It now checks the `ScaffoldMessengerState`'s own `mounted` flag instead.

## Test plan
- [ ] Archive/bin a single story from Home — list updates instantly, no flash
- [ ] Archive/bin/put back stories via multi-select (Home, Archives, Tag view) — no reload flash
- [ ] Put a story back from Archives — it disappears from the Archives list immediately, no manual refresh needed
- [ ] Same put-back check in Bin and Tag view
- [ ] On a tablet-width window, archive/unarchive a story from the Home end drawer and confirm the success snackbar auto-dismisses instead of staying forever

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>